### PR TITLE
One command device creation and initialisation

### DIFF
--- a/data/smartmeter.json
+++ b/data/smartmeter.json
@@ -1,0 +1,35 @@
+{	
+  "name": "smartmeter",
+  "description": "Automatic inputs and feeds creation for smartmeter device.",
+  "inputs": [
+    {
+      "name": "OEMct1",
+      "description": "Power",
+      "processList": [
+        {
+          "process": "1",
+          "arguments": {"type": "ProcessArg::FEEDID", "value": "use" }
+        },
+        {
+          "process": "4",
+          "arguments": {"type": "ProcessArg::FEEDID", "value": "use_kwh" }
+        }
+		  ]
+    }
+  ],
+
+  "feeds": [
+    {
+      "name": "use",
+      "type": "DataType::REALTIME",
+      "engine": "Engine::PHPFINA",
+      "interval": "10"
+    },
+    {
+      "name": "use_kwh",
+      "type": "DataType::REALTIME",
+      "engine": "Engine::PHPFINA",
+      "interval": "10"
+    }
+  ]
+}

--- a/data/smartmeter.json
+++ b/data/smartmeter.json
@@ -3,8 +3,8 @@
   "description": "Automatic inputs and feeds creation for smartmeter device.",
   "inputs": [
     {
-      "name": "OEMct1",
-      "description": "Power",
+      "name": "P1",
+      "description": "CT1 Power",
       "processList": [
         {
           "process": "1",
@@ -13,6 +13,16 @@
         {
           "process": "4",
           "arguments": {"type": "ProcessArg::FEEDID", "value": "use_kwh" }
+        }
+		  ]
+    },
+    {
+      "name": "E1",
+      "description": "CT1 Energy",
+      "processList": [
+        {
+          "process": "34",
+          "arguments": {"type": "ProcessArg::FEEDID", "value": "use_wh" }
         }
 		  ]
     }
@@ -27,6 +37,12 @@
     },
     {
       "name": "use_kwh",
+      "type": "DataType::REALTIME",
+      "engine": "Engine::PHPFINA",
+      "interval": "10"
+    },
+    {
+      "name": "use_wh",
       "type": "DataType::REALTIME",
       "engine": "Engine::PHPFINA",
       "interval": "10"

--- a/device_controller.php
+++ b/device_controller.php
@@ -23,7 +23,11 @@ function device_controller()
 
     if ($route->format == 'json')
     {
-        if ($route->action == 'list') {
+        // Used in conjunction with input name describe to auto create device
+        if ($route->action == "autocreate") {
+            if ($session['userid']>0 && $session['write']) $result = $device->autocreate($session['userid'],get('nodeid'),get('type'));
+        }
+        else if ($route->action == 'list') {
             if ($session['userid']>0 && $session['write']) $result = $device->get_list($session['userid']);
         }
         elseif ($route->action == "create") {

--- a/device_model.php
+++ b/device_model.php
@@ -379,12 +379,17 @@ class Device
           } else {
             $nodeid = $node;
           }
-          $this->log->info("create_inputs() userid=$userid nodeid=$nodeid name=$name description=$description");
-          $inputId = $input->create_input($userid, $nodeid, $name);
-          if(!$input->exists($inputId)) {
-              return false;
+          
+          $inputId = $input->exists_nodeid_name($userid,$nodeid,$name);
+          
+          if ($inputId==false) {
+            $this->log->info("create_inputs() userid=$userid nodeid=$nodeid name=$name description=$description");
+            $inputId = $input->create_input($userid, $nodeid, $name);
+            if(!$input->exists($inputId)) {
+                return false;
+            }
+            $input->set_fields($inputId, '{"description":"'.$description.'"}');
           }
-          $input->set_fields($inputId, '{"description":"'.$description.'"}');
           $i->inputId = $inputId; // Assign the created input id to the inputs array
         }
         return true;


### PR DESCRIPTION
The idea here is to have the option of sending an MQTT message to emoncms phpmqtt_input.php of the form:

    [basetopic]/10/**describe** emontx

and for this then to automatically create a device of type given in the message value (e.g: emontx). Including creation of inputs, input processing and feeds.

This commit includes the device module part of this feature.