### PR TITLE
Device integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,11 +60,11 @@ Click save to continue.
 
 ![3.png](files/3.png)
 
-With the device created the next step is to initialize the device, click on the cycling arrows 'refresh icon' to bring up the initialization window.
+When a new device is created, it will automatically be initialized and all input processes and feeds will be created, according to the pre-defined template. If the template needs to be applied again, as e.g. a process list was experimented on and altered, or single feeds deleted, it may be re-initialized. Clicking the cycling arrows 'refresh icon' will bring up the initialization window.
 
 ![4.png](files/4.png)
 
-Click 'Initialize' to initialize the device which will create the input processes and feeds according to the pre-defined template.
+Click 'Initialize' to re-initialize the device and to confirm the creation of missing feeds and inputs, as well as the reset of configured processes to their original state.
 
 ![5.png](files/5.png)
 

--- a/Views/device.js
+++ b/Views/device.js
@@ -22,22 +22,26 @@ var device = {
 
     'remove':function(id)
     {
-        $.ajax({ url: path+"device/delete.json", data: "id="+id, async: false, success: function(data){} });
+        var result = {};
+        $.ajax({ url: path+"device/delete.json", data: "id="+id, async: false, success: function(data) {result = data;} });
+        return result;
     },
 
     'create':function(nodeid, name, description, type)
     {
-        $.ajax({ url: path+"device/create.json", data: "nodeid="+nodeid+"&name="+name+"&description="+description+"&type="+type, async: false, success: function(data){} });
+        var result = {};
+        $.ajax({ url: path+"device/create.json", data: "nodeid="+nodeid+"&name="+name+"&description="+description+"&type="+type, async: false, success: function(data) {result = data;} });
+        return result;
     },
 
-    'listtemplates':function()
+    'listTemplates':function()
     {
         var result = {};
         $.ajax({ url: path+"device/template/list.json", dataType: 'json', async: false, success: function(data) {result = data;} });
         return result;
     },
 
-    'inittemplate':function(id)
+    'initTemplate':function(id)
     {
         var result = {};
         $.ajax({ url: path+"device/template/init.json", data: "id="+id, dataType: 'json', async: false, success: function(data) {result = data;} });

--- a/Views/device_dialog.js
+++ b/Views/device_dialog.js
@@ -248,7 +248,7 @@ var device_dialog =
                 
                 if (device_dialog.device != null) {
                     var fields = {};
-                    if (device_dialog.device.nodeid != node) fields['node'] = node;
+                    if (device_dialog.device.nodeid != node) fields['nodeid'] = node;
                     if (device_dialog.device.name != name) fields['name'] = name;
                     if (device_dialog.device.description != desc) fields['description'] = desc;
                     if (device_dialog.device.type != device_dialog.deviceType) {
@@ -268,7 +268,7 @@ var device_dialog =
                     if (device_dialog.device.type != device_dialog.deviceType
                             && device_dialog.deviceType != null) {
                         
-                        var result = device.inittemplate(device_dialog.device.id);
+                        var result = device.initTemplate(device_dialog.device.id);
                         if (typeof result.success !== 'undefined' && !result.success) {
                             alert('Unable to initialize device:\n'+result.message);
                             return false;
@@ -280,7 +280,7 @@ var device_dialog =
                     update();
                     
                     if (id && device_dialog.deviceType != null) {
-                        var result = device.inittemplate(id);
+                        var result = device.initTemplate(id);
                         if (typeof result.success !== 'undefined' && !result.success) {
                             alert('Unable to initialize device:\n'+result.message);
                             return false;
@@ -316,7 +316,7 @@ var device_dialog =
     'registerInitEvents':function() {
         
         $("#device-init-confirm").off('click').on('click', function() {
-            var result = device.inittemplate(device_dialog.device.id);
+            var result = device.initTemplate(device_dialog.device.id);
 
             if (typeof result.success !== 'undefined' && !result.success) {
                 alert('Unable to initialize device:\n'+result.message);

--- a/Views/device_dialog.js
+++ b/Views/device_dialog.js
@@ -276,11 +276,15 @@ var device_dialog =
                     }
                 }
                 else {
-                    var id = device.create(node, name, desc, device_dialog.deviceType);
+                    var result = device.create(node, name, desc, device_dialog.deviceType);
+                    if (typeof result.success !== 'undefined' && !result.success) {
+                        alert('Unable to create device:\n'+result.message);
+                        return false;
+                    }
                     update();
                     
-                    if (id && device_dialog.deviceType != null) {
-                        var result = device.initTemplate(id);
+                    if (result && device_dialog.deviceType != null) {
+                        var result = device.initTemplate(result);
                         if (typeof result.success !== 'undefined' && !result.success) {
                             alert('Unable to initialize device:\n'+result.message);
                             return false;

--- a/Views/device_dialog.php
+++ b/Views/device_dialog.php
@@ -116,7 +116,7 @@
            <br>
            <?php echo _('Initializing a device usualy should only be done once on installation.'); ?>
            <br>
-           <?php echo _('If the configuration was already applied, only missing inputs and feeds will be created.'); ?>
+           <?php echo _('If the configuration was already applied, missing feeds and inputs will be created and configured processes reset to their original state.'); ?>
            <br><br>
         </p>
     </div>

--- a/Views/device_view.php
+++ b/Views/device_view.php
@@ -28,11 +28,11 @@
 
     <div id="device-none" class="hide">
         <div class="alert alert-block">
-            <h4 class="alert-heading"><?php echo _('No device connections'); ?></h4><br>
+            <h4 class="alert-heading"><?php echo _('No devices'); ?></h4><br>
             <p>
-                <?php echo _('Device connections are used to configure and prepare the communication with different metering units.'); ?>
+                <?php echo _('Devices are used to configure and prepare the communication with different physical devices.'); ?>
                 <br><br>
-                <?php echo _('A device configures and prepares inputs, feeds possible device channels, representing e.g. different registers of defined metering units (see the channels tab).'); ?>
+                <?php echo _('A device configures and prepares inputs, feeds possible other settings, representing e.g. different registers of defined metering units.'); ?>
                 <br>
                 <?php echo _('You may want the next link as a guide for generating your request: '); ?><a href="api"><?php echo _('Device API helper'); ?></a>
             </p>
@@ -104,11 +104,11 @@
 
       table.draw();
       if (table.data.length != 0) {
-        $("#nodevices").hide();
-        $("#localheading").show();
+        $("#device-none").hide();
+        $("#local-header").show();
       } else {
-        $("#nodevices").show();
-        $("#localheading").hide();
+        $("#device-none").show();
+        $("#local-header").hide();
       }
     }});
   }

--- a/device_menu.php
+++ b/device_menu.php
@@ -4,4 +4,10 @@
     bindtextdomain($domain, "Modules/device/locale");
     bind_textdomain_codeset($domain, 'UTF-8');
 
-    $menu_dropdown_config[] = array('name'=> dgettext($domain, "Device Setup"), 'icon'=>'icon-home', 'path'=>"device/view" , 'session'=>"write", 'order' => 45 );
+    $menu_dropdown_config[] = array(
+            'name'=> dgettext($domain, "Device Setup"),
+            'icon'=>'icon-home',
+            'path'=>"device/view" ,
+            'session'=>"write",
+            'order' => 45
+    );


### PR DESCRIPTION
Hi guys,

this small contribution contains just some few bugfixes as a reaction to your forum post regarding the [planned release](https://community.openenergymonitor.org/t/development-devices-inputs-and-feeds-in-emoncms/4281/24). I had those fixes in another branch for quite a while now to be honest, but I created these few commits now separately, as everything else would probably be an overkill before the merge.

- device view API hint for empty device lists did not show
- device creation alert for existing device name/node combinations not showing
- device.js create and delete ajax calls did not return their responses, resulting in the originally planned immediate device-initialization not working. The dialog was trying to use the returned device id, which was always undefined

I do not see any reason to not immediately initialize the devices when they are created to be honest, especially now with the dialog. I hence updated the readme already, to reflect to the template being initialized at device creation ;)