### PR TITLE
Improve caching and fix set_processlist

### DIFF
--- a/Views/device_dialog.php
+++ b/Views/device_dialog.php
@@ -111,12 +111,11 @@
     </div>
     <div class="modal-body">
         <p><?php echo _('Defaults, like inputs and associated feeds will be automaticaly configured.'); ?>
+           <br>
+           <?php echo _('Only missing inputs and feeds will be recreated. Feed configurations will be considered unique in combination with their tag.'); ?>
            <br><br>
-           <?php echo _('Make sure the selected device node and type are correcly configured before proceding.'); ?>
-           <br>
-           <?php echo _('Initializing a device usualy should only be done once on installation.'); ?>
-           <br>
-           <?php echo _('If the configuration was already applied, missing feeds and inputs will be created and configured processes reset to their original state.'); ?>
+           <b><?php echo _('Warning: '); ?></b>
+           <?php echo _('All configured input and feed processes will be reset to their original state.'); ?>
            <br><br>
         </p>
     </div>
@@ -136,7 +135,7 @@
            <br><br>
            <?php echo _('If this device is active and is using a device key, it will no longer be able to post data.'); ?>
            <br><br>
-           <?php echo _('Inputs and Feeds that this device uses are not deleted and all historic data is kept. To remove them, deleted manualy afterwards.'); ?>
+           <?php echo _('Inputs and Feeds that this device uses are not deleted and all historic data is kept. To remove them, delete them manualy afterwards.'); ?>
            <br><br>
            <?php echo _('Are you sure you want to delete?'); ?>
         </p>

--- a/device_controller.php
+++ b/device_controller.php
@@ -15,7 +15,7 @@ function device_controller()
     if ($route->format == 'html')
     {
         if ($route->action == "view" && $session['write']) {
-            $device_templates = $device->get_template_list_short();
+            $device_templates = $device->get_template_list_meta();
             $result = view("Modules/device/Views/device_view.php",array('devices'=>$device_templates));
         }
         if ($route->action == 'api') $result = view("Modules/device/Views/device_api.php", array());
@@ -69,19 +69,19 @@ function device_controller()
         else if ($route->action == 'list') {
             if ($session['userid']>0 && $session['write']) $result = $device->get_list($session['userid']);
         }
-        elseif ($route->action == "create") {
+        else if ($route->action == "create") {
             if ($session['userid']>0 && $session['write']) $result = $device->create($session['userid'],get("nodeid"),get("name"),get("description"),get("type"));
         }
         // Used in conjunction with input name describe to auto create device
         else if ($route->action == "autocreate") {
             if ($session['userid']>0 && $session['write']) $result = $device->autocreate($session['userid'],get('nodeid'),get('type'));
         }
-        elseif ($route->action == "template" && $route->subaction != "init") {
+        else if ($route->action == "template" && $route->subaction != "init") {
             if ($route->subaction == "list") {
                 if ($session['userid']>0 && $session['write']) $result = $device->get_template_list();
             }
-            elseif ($route->subaction == "listshort") {
-                if ($session['userid']>0 && $session['write']) $result = $device->get_template_list_short();
+            else if ($route->subaction == "listshort") {
+                if ($session['userid']>0 && $session['write']) $result = $device->get_template_list_meta();
             }
             else if ($route->subaction == "get") {
                 if ($session['userid']>0 && $session['write']) $result = $device->get_template(get('device'));
@@ -96,7 +96,8 @@ function device_controller()
                     if ($route->action == "get") $result = $deviceget;
                     else if ($route->action == "delete") $result = $device->delete($deviceid);
                     else if ($route->action == 'set') $result = $device->set_fields($deviceid, get('fields'));
-                    else if ($route->action == 'template' && $route->subaction == 'init') {
+                    else if ($route->action == 'template' && 
+                            $route->subaction == 'init') {
                         if (isset($_GET['type'])) {
                             $device->set_fields($deviceid, json_encode(array("type"=>$_GET['type'])));
                         }
@@ -107,7 +108,7 @@ function device_controller()
             else {
                 $result = array('success'=>false, 'message'=>'Device does not exist');
             }
-        }     
+        }
     }
 
     return array('content'=>$result);


### PR DESCRIPTION
Hi again^^

I decided to patch a few more changes from our fork to this repo right now and made an additional bugfix I just noticed to exist. From a front-end site nothing much should change what so ever.

First, I modified the initialization dialog text, as to make a little more clear what will happen. Together with a "<b>Warning:</b> All configured input and feed processes will be reset to their original state."

Next, I implemented redis caching for template meta data, as it was getting more and more info and I thought this may be cleaner than a simple browser cache.
Further, I fixed a caching error for devices, where `$device->get($id)` would check `if (!$this->exist($id))` and return a `"success"=>false` if not.
This killed the device_controller though, as he tries to access the userid of the returned device array.

                $deviceget = $device->get($deviceid);
                if (isset($session['write']) && $session['write'] && $session['userid']>0 && $deviceget['userid']==$session['userid']) {
                ...

I hence improved the device redis caching and the $get() and $exists() functions.
Maybe this was the crash condition you mentioned in your last commit @TrystanLea ?

At last, I realized that the current $input/$feed->set_processlist() functions need a userid and the process_list to work as a result of the group support?
I hence fixed the template process creation, which did not work anymore.


Quite a lot in one single pull request, as I realized just now^^
Hope this is not too much to check at once.

Liebe Grüße
Adrian