### PR TITLE
Improve template reload functionality

### DIFF
--- a/device_controller.php
+++ b/device_controller.php
@@ -15,12 +15,8 @@ function device_controller()
     if ($route->format == 'html')
     {
         if ($route->action == "view" && $session['write']) {
-        
-            // Clear template cache, force reload
-            if ($redis) $redis->delete("device:template:keys");
-            
-            $device_templates = $device->get_template_list_meta();
-            $result = view("Modules/device/Views/device_view.php",array('devices'=>$device_templates));
+            $templates = $device->get_template_list();
+            $result = view("Modules/device/Views/device_view.php",array('devices'=>$templates));
         }
         if ($route->action == 'api') $result = view("Modules/device/Views/device_api.php", array());
     }
@@ -91,7 +87,7 @@ function device_controller()
         }
         else if ($route->action == "template" && $route->subaction != "init") {
             if ($route->subaction == "list") {
-                if ($session['userid']>0 && $session['write']) $result = $device->get_template_list();
+                if ($session['userid']>0 && $session['write']) $result = $device->get_template_list_full();
             }
             else if ($route->subaction == "listshort") {
                 if ($session['userid']>0 && $session['write']) $result = $device->get_template_list_meta();
@@ -107,9 +103,9 @@ function device_controller()
                 $deviceget = $device->get($deviceid);
                 if (isset($session['write']) && $session['write'] && $session['userid']>0 && $deviceget['userid']==$session['userid']) {
                     if ($route->action == "get") $result = $deviceget;
-                    else if ($route->action == "setnewdevicekey") $result = $device->set_new_devicekey($deviceid);
                     else if ($route->action == "delete") $result = $device->delete($deviceid);
                     else if ($route->action == 'set') $result = $device->set_fields($deviceid, get('fields'));
+                    else if ($route->action == "setnewdevicekey") $result = $device->set_new_devicekey($deviceid);
                     else if ($route->action == 'template' && 
                             $route->subaction == 'init') {
                         if (isset($_GET['type'])) {

--- a/device_model.php
+++ b/device_model.php
@@ -440,11 +440,20 @@ class Device
         } else {
             return false;
         }
-    } 
+    }
 
     public function get_template_list()
     {
-        return $this->load_modules();
+        // This is called when the device view gets reloaded.
+        // Always cache and reload all templates here.
+        $this->load_template_list();
+        
+        return $this->get_template_list_meta();
+    }
+    
+    public function get_template_list_full()
+    {
+        return $this->load_template_list();
     }
 
     public function get_template_list_meta()
@@ -452,7 +461,7 @@ class Device
         $templates = array();
         
         if ($this->redis) {
-            if (!$this->redis->exists("device:template:keys")) $this->load_modules();
+            if (!$this->redis->exists("device:template:keys")) $this->load_template_list();
             
             $keys = $this->redis->sMembers("device:template:keys");
             foreach ($keys as $key)    {
@@ -463,7 +472,7 @@ class Device
         }
         else {
             if (empty($this->templates)) { // Cache it now
-                $this->load_modules();
+                $this->load_template_list();
             }
             $templates = $this->templates;
         }
@@ -492,7 +501,7 @@ class Device
         
         if ($this->redis) {
             if (!$this->redis->exists("device:template:$key")) {
-                $this->load_modules();
+                $this->load_template_list();
             }
             if ($this->redis->exists("device:template:$key")) {
                 $template = $this->redis->hGetAll("device:template:$key");
@@ -500,7 +509,7 @@ class Device
         }
         else {
             if (empty($this->templates)) { // Cache it now
-                $this->load_modules();
+                $this->load_template_list();
             }
             if (isset($this->templates[$key])) {
                 $template = $this->templates[$key];
@@ -534,7 +543,7 @@ class Device
         return array('success'=>false, 'message'=>'Unknown error while initializing device');
     }
 
-    private function load_modules()
+    private function load_template_list()
     {
         if ($this->redis) {
             $this->redis->delete("device:template:keys");


### PR DESCRIPTION
Hi guys,

it took a while but here is the small commit [as announced](https://community.openenergymonitor.org/t/development-devices-inputs-and-feeds-in-emoncms/4281/95?u=adminde). ;)

Just a small commit to avoid the resetting of redis values in the controller function and to enable the device reload for non-redis systems.