### PR TITLE
Dry-run prepare initialization

### DIFF
--- a/Views/device.js
+++ b/Views/device.js
@@ -20,6 +20,13 @@ var device = {
         return result;
     },
 
+    'setNewDeviceKey':function(id)
+    {
+        var result = {};
+        $.ajax({ url: path+"device/setnewdevicekey.json", data: "id="+id, async: false, success: function(data) {result = data;} });
+        return result;
+    },
+
     'remove':function(id)
     {
         var result = {};
@@ -33,13 +40,6 @@ var device = {
         $.ajax({ url: path+"device/create.json", data: "nodeid="+nodeid+"&name="+name+"&description="+description+"&type="+type, async: false, success: function(data) {result = data;} });
         return result;
     },
-    
-    'setnewdevicekey':function(id)
-    {
-        var result = {};
-        $.ajax({ url: path+"device/setnewdevicekey.json", data: "id="+id, async: false, success: function(data) {result = data;} });
-        return result;
-    },
 
     'listTemplates':function()
     {
@@ -48,10 +48,17 @@ var device = {
         return result;
     },
 
-    'initTemplate':function(id)
+    'prepareTemplate':function(id)
     {
         var result = {};
-        $.ajax({ url: path+"device/template/init.json", data: "id="+id, dataType: 'json', async: false, success: function(data) {result = data;} });
+        $.ajax({ url: path+"device/template/prepare.json", data: "id="+id, dataType: 'json', async: false, success: function(data) {result = data;} });
+        return result;
+    },
+
+    'initTemplate':function(id, template)
+    {
+        var result = {};
+        $.ajax({ url: path+"device/template/init.json", data: "id="+id+"&template="+JSON.stringify(template), dataType: 'json', async: false, success: function(data) {result = data;} });
         return result;
     }
 }

--- a/Views/device_api.php
+++ b/Views/device_api.php
@@ -46,6 +46,7 @@
     <tr><td><?php echo _('List templates'); ?></td><td><a href="<?php echo $path; ?>device/template/list.json"><?php echo $path; ?>device/template/list.json</a></td></tr>
     <tr><td><?php echo _('List templates short'); ?></td><td><a href="<?php echo $path; ?>device/template/listshort.json"><?php echo $path; ?>device/template/listshort.json</a></td></tr>
     <tr><td><?php echo _('get template details'); ?></td><td><a href="<?php echo $path; ?>device/template/get.json?device=example"><?php echo $path; ?>device/template/get.json?device=example</a></td></tr>
+    <tr><td><?php echo _('Prepare device initialization'); ?></td><td><a href="<?php echo $path; ?>device/template/prepare.json?id=1"><?php echo $path; ?>device/template/prepare.json?id=1</a></td></tr>
     <tr><td><?php echo _('Initialize device'); ?></td><td><a href="<?php echo $path; ?>device/template/init.json?id=1"><?php echo $path; ?>device/template/init.json?id=1</a></td></tr>
 </table>
 

--- a/Views/device_dialog.js
+++ b/Views/device_dialog.js
@@ -1,6 +1,7 @@
 var device_dialog =
 {
     templates: null,
+    deviceTemplate: null,
     deviceType: null,
     device: null,
     
@@ -8,18 +9,14 @@ var device_dialog =
         this.templates = templates;
         
         if (device != null) {
+            this.deviceTemplate = null;
             this.deviceType = device.type;
             this.device = device;
-            $("#device-init").show();
-            $("#device-save").html("Save");
-            $("#device-new-devicekey").show();
         }
         else {
+            this.deviceTemplate = null;
             this.deviceType = null;
             this.device = null;
-            $("#device-init").hide();
-            $("#device-save").html("Save & Initialize");
-            $("#device-new-devicekey").hide();
         }
         
         this.drawConfig();
@@ -128,19 +125,24 @@ var device_dialog =
         $('#template-tooltip').attr("title", tooltip).tooltip({html: true});
         
         if (this.device != null) {
-        
             $('#device-config-node').val(this.device.nodeid);
             $('#device-config-name').val(this.device.name);
             $('#device-config-description').val(this.device.description);
-            $('#device-config-devicekey').val(this.device.devicekey);
+            $('#device-config-devicekey').val(this.device.devicekey).prop("disabled", false);
+            $("#device-config-devicekey-new").prop("disabled", false);
             $('#device-config-delete').show();
+            $("#device-init").show();
+            $("#device-save").html("Save");
         }
         else {
             $('#device-config-node').val('');
             $('#device-config-name').val('');
             $('#device-config-description').val('');
-            $('#device-config-devicekey').val("Device not yet created");
+            $('#device-config-devicekey').val('').prop("disabled", true);
+            $("#device-config-devicekey-new").prop("disabled", true);
             $('#device-config-delete').hide();
+            $("#device-init").hide();
+            $("#device-save").html("Save & Initialize");
         }
     },
 
@@ -227,14 +229,14 @@ var device_dialog =
                 var template = device_dialog.templates[type];
                 $('#template-description').html('<em style="color:#888">'+template.description+'</em>');
                 $('#template-info').show();
+                $("#device-init").hide();
             }
             else {
                 device_dialog.deviceType = null;
                 $('#template-description').text('');
                 $('#template-info').hide();
+                $("#device-init").show()
             }
-            
-            if (device_dialog.deviceType!=device_dialog.device.type) $("#device-init").hide(); else $("#device-init").show();
         });
 
         $("#sidebar-open").off('click').on('click', function () {
@@ -256,6 +258,7 @@ var device_dialog =
                 var desc = $('#device-config-description').val();
                 var devicekey = $('#device-config-devicekey').val();
                 
+                var init = false;
                 if (device_dialog.device != null) {
                     var fields = {};
                     if (device_dialog.device.nodeid != node) fields['nodeid'] = node;
@@ -266,6 +269,7 @@ var device_dialog =
                     if (device_dialog.device.type != device_dialog.deviceType) {
                         if (device_dialog.deviceType != null) {
                             fields['type'] = device_dialog.deviceType;
+                            init = true;
                         }
                         else fields['type'] = '';
                     }
@@ -276,11 +280,6 @@ var device_dialog =
                         return false;
                     }
                     update();
-                    
-                    if (device_dialog.device.type != device_dialog.deviceType && device_dialog.deviceType != null) {
-                        $('#device-config-modal').modal('hide');
-                        device_dialog.loadInit(false); // skip_check = false
-                    }
                 }
                 else {
                     var result = device.create(node, name, desc, device_dialog.deviceType);
@@ -288,15 +287,17 @@ var device_dialog =
                         alert('Unable to create device:\n'+result.message);
                         return false;
                     }
+                    init = true;
+                    device_dialog.device = {
+                            id: result,
+                            nodeid: node,
+                            name: name,
+                            type: device_dialog.deviceType
+                    };
                     update();
-                    
-                    if (result && device_dialog.deviceType != null) {
-                        $('#device-config-modal').modal('hide');
-                        device_dialog.device = {id: result, name: name};
-                        device_dialog.loadInit(false); // skip_check = false
-                    }
                 }
                 $('#device-config-modal').modal('hide');
+                if (init) device_dialog.loadInit();
             }
             else {
                 alert('Device needs to be configured first.');
@@ -311,50 +312,183 @@ var device_dialog =
         
         $("#device-init").off('click').on('click', function () {
             $('#device-config-modal').modal('hide');
-            device_dialog.loadInit(false); // skip_check = true
+            device_dialog.loadInit();
         });
         
-        $("#device-new-devicekey").off('click').on('click', function () {
-            device_dialog.device.devicekey = device.setnewdevicekey(device_dialog.device.id);
+        $("#device-config-devicekey-new").off('click').on('click', function () {
+            device_dialog.device.devicekey = device.setNewDeviceKey(device_dialog.device.id);
             $('#device-config-devicekey').val(device_dialog.device.devicekey);
         });        
         
-       
     },
 
-    'loadInit': function(skip_check) {
-        
-        $('#device-init-modal').modal('show');
-        $('#device-init-modal-label').html('Initialize Device: <b>'+device_dialog.device.name+'</b>');             
-        
-        // Initialize callbacks
-        if (!skip_check) {
-            $(".pre-init").show(); $(".post-init").hide();  
-            
-            $("#device-init-confirm").off('click').on('click', function() {
-                var result = device.initTemplate(device_dialog.device.id);
-                device_dialog.showInitLog(result);
-            });
-        } else {
-            var result = device.initTemplate(device_dialog.device.id);
-            device_dialog.showInitLog(result);
-        }
-    },
-    
-    'showInitLog': function (result) {
-
-        $(".pre-init").hide(); $(".post-init").show();
-        
+    'loadInit': function() {
+        var result = device.prepareTemplate(device_dialog.device.id);
         if (typeof result.success !== 'undefined' && !result.success) {
             alert('Unable to initialize device:\n'+result.message);
             return false;
         }
-              
-        if (result.log!=undefined) {
-            $("#device-init-modal-log").html("<b>Device initialized</b><br><pre>"+result.log+"</pre>");
-        } 
+        device_dialog.deviceTemplate = result;
+        device_dialog.drawInit(result);
+        
+        // Initialize callbacks
+        $("#device-init-confirm").off('click').on('click', function() {
+            $('#device-init-modal').modal('hide');
+            
+            var template = device_dialog.parseTemplate();
+            var result = device.initTemplate(device_dialog.device.id, template);
+            if (typeof result.success !== 'undefined' && !result.success) {
+                alert('Unable to initialize device:\n'+result.message);
+                return false;
+            }
+        });
+    },
+
+    'drawInit': function (result) {
+        $('#device-init-modal').modal('show');
+        $('#device-init-modal-label').html('Initialize Device: <b>'+device_dialog.device.name+'</b>');  
+        
+        if (typeof result.feeds !== 'undefined' && result.feeds.length > 0) {
+            $('#device-init-feeds').show();
+            var table = "";
+            for (var i = 0; i < result.feeds.length; i++) {
+                var feed = result.feeds[i];
+                var row = "";
+                if (feed.action.toLowerCase() == "none") {
+                    row += "<td><input class='input-select' type='checkbox' checked disabled /></td>";
+                }
+                else {
+                    row += "<td><input class='input-select' type='checkbox' checked /></td>";
+                }
+                row += "<td>"+device_dialog.drawInitAction(feed.action)+"</td>"
+                row += "<td>"+feed.tag+"</td><td>"+feed.name+"</td>";
+                row += "<td>"+device_dialog.drawInitProcessList(feed.processList)+"</td>";
+                
+                table += "<tr>"+row+"</tr>";
+            }
+            $('#device-init-feeds-table').html(table);
+        }
+        else {
+            $('#device-init-feeds').hide();
+        }
+        
+        if (typeof result.inputs !== 'undefined' && result.inputs.length > 0) {
+            $('#device-init-inputs').show();
+            var table = "";
+            for (var i = 0; i < result.inputs.length; i++) {
+                var input = result.inputs[i];
+                var row = "";
+                if (input.action.toLowerCase() == "none") {
+                    row += "<td><input class='input-select' type='checkbox' checked disabled /></td>";
+                }
+                else {
+                    row += "<td><input class='input-select' type='checkbox' checked /></td>";
+                }
+                row += "<td>"+device_dialog.drawInitAction(input.action)+"</td>"
+                row += "<td>"+input.node+"</td><td>"+input.name+"</td><td>"+input.description+"</td>";
+                row += "<td>"+device_dialog.drawInitProcessList(input.processList)+"</td>";
+                
+                table += "<tr>"+row+"</tr>";
+            }
+            $('#device-init-inputs-table').html(table);
+        }
+        else {
+            $('#device-init-inputs').hide();
+            $('#device-init-inputs-table').html("");
+        }
         
         return true;
+    },
+
+    'drawInitAction': function (action) {
+        action = action.toLowerCase();
+        
+        var color;
+        if (action === 'create' || action === 'set') {
+            color = "rgb(0,110,205)";
+        }
+        else if (action === 'override') {
+            color = "rgb(255,125,20)";
+        }
+        else {
+            color = "rgb(50,200,50)";
+            action = "exists"
+        }
+        action = action.charAt(0).toUpperCase() + action.slice(1);
+        
+        return "<span style='color:"+color+";'>"+action+"</span>";
+    },
+
+    'drawInitProcessList': function (processList) {
+        if (!processList || processList.length < 1) return "";
+        var out = "";
+        for (var i = 0; i < processList.length; i++) {
+            var process = processList[i];
+            if (process['arguments'] != undefined && process['arguments']['value'] != undefined && process['arguments']['type'] != undefined) {
+                var name = "<small>"+process["name"]+"</small>";
+                var value = process['arguments']['value'];
+                
+                var title;
+                var color = "info";
+                switch(process['arguments']['type']) {
+                case 0: // VALUE
+                    title = "Value: " + value;
+                    break;
+                    
+                case 1: //INPUTID
+                    title = "Input: " + value;
+                    break;
+                    
+                case 2: //FEEDID
+                    title = "Feed: " + value;
+                    break;
+                    
+                case 4: // TEXT
+                    title = "Text: " + value;
+                    break;
+
+                case 5: // SCHEDULEID
+                    title = "Schedule: " + value;
+                    break;
+
+                default:
+                    title = value;
+                    break;
+                }
+                out += "<span class='label label-"+color+"' title='"+title+"' style='cursor:default'>"+name+"</span> ";
+            }
+        }
+        return out;
+    },
+
+    'parseTemplate': function() {
+        var template = {};
+
+        template['feeds'] = [];
+        if (typeof device_dialog.deviceTemplate.feeds !== 'undefined' && 
+                device_dialog.deviceTemplate.feeds.length > 0) {
+            
+            var feeds = device_dialog.deviceTemplate.feeds;
+            $("#device-init-feeds-table tr").find('input[type="checkbox"]:checked')
+                    .each(function (i, row) {
+                
+                template['feeds'].push(feeds[i]); 
+            });
+        }
+        
+        template['inputs'] = [];
+        if (typeof device_dialog.deviceTemplate.inputs !== 'undefined' && 
+                device_dialog.deviceTemplate.inputs.length > 0) {
+            
+            var inputs = device_dialog.deviceTemplate.inputs;
+            $("#device-init-inputs-table tr").find('input[type="checkbox"]:checked')
+                    .each(function (i, row) {
+                
+                template['inputs'].push(inputs[i]); 
+            });
+        }
+        
+        return template;
     },
 
     'loadDelete': function(device, tablerow) {
@@ -375,7 +509,7 @@ var device_dialog =
                 table.remove(row);
                 update();
             }
-            else if (typeof device_dialog.device.inputs != undefined) {
+            else if (typeof device_dialog.device.inputs !== 'undefined') {
                 // If the table row is undefined and an input list exists, the config dialog
                 // was opened in the input view and all corresponding inputs will be deleted
                 var inputIds = [];

--- a/Views/device_dialog.php
+++ b/Views/device_dialog.php
@@ -39,6 +39,7 @@
         margin-top: -15px;
         margin-left: 250px;
     }
+
     #content-wrapper .divider {
         *width: 100%;
         height: 1px;
@@ -52,6 +53,26 @@
     #template-info .tooltip-inner {
         max-width: 500px;
     }
+    
+    input[type="checkbox"] { margin:0px; }
+    
+    #device-init-modal {
+        width: 50%; left:25%; /* (100%-width)/2 */
+        margin-left: auto; margin-right: auto;
+    }
+    
+    #device-init-modal table td { text-align: left; }
+    
+    #device-init-feeds table td:nth-of-type(1) { width:14px; text-align: center; }
+    #device-init-feeds table td:nth-of-type(2) { width:5%; }
+    #device-init-feeds table td:nth-of-type(3) { width:15%; }
+    #device-init-feeds table td:nth-of-type(4) { width:25%; }
+    
+    #device-init-inputs table td:nth-of-type(1) { width:14px; text-align: center; }
+    #device-init-inputs table td:nth-of-type(2) { width:5%; }
+    #device-init-inputs table td:nth-of-type(3) { width:5%; }
+    #device-init-inputs table td:nth-of-type(4) { width:10%; }
+    #device-init-inputs table td:nth-of-type(5) { width:25%; }
 </style>
 
 <div id="device-config-modal" class="modal hide keyboard modal-adjust" tabindex="-1" role="dialog" aria-labelledby="device-config-modal-label" aria-hidden="true" data-backdrop="static">
@@ -89,17 +110,17 @@
             
             <label><b><?php echo _('Node'); ?></b></label>
             <input id="device-config-node" class="input-medium" type="text">
-                    
+            
             <label><b><?php echo _('Name'); ?></b></label>
             <input id="device-config-name" class="input-large" type="text">
-                    
+             
             <label><b><?php echo _('Location'); ?></b></label>
             <input id="device-config-description" class="input-large" type="text">
             
             <label><b><?php echo _('Device Key'); ?></b></label>
             <div class="input-append">
-            <input id="device-config-devicekey" class="input-large" type="text" style="width:260px">
-            <button id="device-new-devicekey" class="btn">New</button>
+                <input id="device-config-devicekey" class="input-large" type="text" style="width:260px">
+                <button id="device-config-devicekey-new" class="btn">New</button>
             </div>
         </div>
     </div>
@@ -117,22 +138,42 @@
         <h3 id="device-init-modal-label"><?php echo _('Initialize device'); ?></h3>
     </div>
     <div class="modal-body">
-        <div id="device-init-modal-content" class="pre-init">
-        <p><?php echo _('Defaults, like inputs and associated feeds will be automaticaly configured.'); ?>
-           <br>
-           <?php echo _('Only missing inputs and feeds will be recreated. Feed configurations will be considered unique in combination with their tag.'); ?>
-           <br><br>
-           <b><?php echo _('Warning: '); ?></b>
-           <?php echo _('All configured input and feed processes will be reset to their original state.'); ?>
-           <br><br>
+        <p><?php echo _('Initializing a device will automaticaly configure inputs and associated feeds as described.'); ?><br>
+            <b><?php echo _('Warning: '); ?></b><?php echo _('Process lists with dependencies to deselected feeds or inputs will be skipped as a whole'); ?>
         </p>
+        
+        <div id="device-init-feeds" style="display:none">
+            <label><b><?php echo _('Feeds'); ?></b></label>
+            <table class="table table-hover">
+                <tr>
+                    <th></th>
+                    <th></th>
+                    <th><?php echo _('Tag'); ?></th>
+                    <th><?php echo _('Name'); ?></th>
+                    <th><?php echo _('Process list'); ?></th>
+                </tr>
+                <tbody id="device-init-feeds-table"></tbody>
+            </table>
         </div>
-        <div id="device-init-modal-log" class="hide post-init"></div>
+        
+        <div id="device-init-inputs" style="display:none">
+            <label><b><?php echo _('Inputs'); ?></b></label>
+            <table class="table table-hover">
+                <tr>
+                    <th></th>
+                    <th></th>
+                    <th><?php echo _('Node'); ?></th>
+                    <th><?php echo _('Key'); ?></th>
+                    <th><?php echo _('Name'); ?></th>
+                    <th><?php echo _('Process list'); ?></th>
+                </tr>
+                <tbody id="device-init-inputs-table"></tbody>
+            </table>
+        </div>
     </div>
     <div class="modal-footer">
-        <button id="device-init-ok" class="btn post-init hide" data-dismiss="modal" aria-hidden="true"><?php echo _('Ok'); ?></button>
-        <button id="device-init-cancel" class="btn pre-init" data-dismiss="modal" aria-hidden="true"><?php echo _('Cancel'); ?></button>
-        <button id="device-init-confirm" class="btn btn-primary pre-init"><?php echo _('Initialize'); ?></button>
+        <button id="device-init-cancel" class="btn" data-dismiss="modal" aria-hidden="true"><?php echo _('Cancel'); ?></button>
+        <button id="device-init-confirm" class="btn btn-primary"><?php echo _('Initialize'); ?></button>
     </div>
 </div>
 

--- a/Views/device_view.php
+++ b/Views/device_view.php
@@ -63,9 +63,7 @@
     'dummy-5':{'title':'', 'type':"blank"},
     'time':{'title':'<?php echo _('Updated'); ?>', 'type':"group-updated"},
     'dummy-7':{'title':'', 'type':"blank"},
-    'dummy-8':{'title':'', 'type':"blank"},
-    'dummy-9':{'title':'', 'type':"blank"},
-    'dummy-10':{'title':'', 'type':"blank"}
+    'dummy-8':{'title':'', 'type':"blank"}
   }
   
   table.deletedata = false;

--- a/data/OpenEnergyMonitor/emonpi-HEM.json
+++ b/data/OpenEnergyMonitor/emonpi-HEM.json
@@ -10,11 +10,11 @@
             "processList": [
                 {
                     "process": "log_to_feed",
-                    "arguments": {"type": "ProcessArg::FEEDID", "value": "use" }
+                    "arguments": { "type": "ProcessArg::FEEDID", "value": "use" }
                 },
                 {
                     "process": "power_to_kwh",
-                    "arguments": {"type": "ProcessArg::FEEDID", "value": "use_kwh" }
+                    "arguments": { "type": "ProcessArg::FEEDID", "value": "use_kwh" }
                 }
             ]
         }

--- a/data/OpenEnergyMonitor/emonth.json
+++ b/data/OpenEnergyMonitor/emonth.json
@@ -8,20 +8,20 @@
             "name": "temperature",
             "description": "Temperature C",
             "processList": [
-            {
-                "process": "log_to_feed",
-                "arguments": {"type": "ProcessArg::FEEDID", "value": "emonth_temperature" }
-            }
+                {
+                    "process": "log_to_feed",
+                    "arguments": {"type": "ProcessArg::FEEDID", "value": "emonth_temperature" }
+                }
             ]
         },
         {
             "name": "humidity",
             "description": "Humidity Rh%",
             "processList": [
-            {
-                "process": "log_to_feed",
-                "arguments": {"type": "ProcessArg::FEEDID", "value": "emonth_humidity" }
-            }
+                {
+                    "process": "log_to_feed",
+                    "arguments": {"type": "ProcessArg::FEEDID", "value": "emonth_humidity" }
+                }
             ]
         }
     ],
@@ -31,7 +31,7 @@
             "name": "emonth_temperature",
             "type": "DataType::REALTIME",
             "engine": "Engine::PHPFINA",
-            "interval": "60",
+            "interval": "60"
         },
         {
             "name": "emonth_humidity",

--- a/device_controller.php
+++ b/device_controller.php
@@ -15,12 +15,8 @@ function device_controller()
     if ($route->format == 'html')
     {
         if ($route->action == "view" && $session['write']) {
-        
-            // Clear template cache, force reload
-            if ($redis) $redis->delete("device:template:keys");
-            
-            $device_templates = $device->get_template_list_meta();
-            $result = view("Modules/device/Views/device_view.php",array('devices'=>$device_templates));
+            $templates = $device->get_template_list();
+            $result = view("Modules/device/Views/device_view.php",array('devices'=>$templates));
         }
         if ($route->action == 'api') $result = view("Modules/device/Views/device_api.php", array());
     }
@@ -91,7 +87,7 @@ function device_controller()
         }
         else if ($route->action == "template" && $route->subaction != "init") {
             if ($route->subaction == "list") {
-                if ($session['userid']>0 && $session['write']) $result = $device->get_template_list();
+                if ($session['userid']>0 && $session['write']) $result = $device->get_template_list_full();
             }
             else if ($route->subaction == "listshort") {
                 if ($session['userid']>0 && $session['write']) $result = $device->get_template_list_meta();
@@ -107,9 +103,9 @@ function device_controller()
                 $deviceget = $device->get($deviceid);
                 if (isset($session['write']) && $session['write'] && $session['userid']>0 && $deviceget['userid']==$session['userid']) {
                     if ($route->action == "get") $result = $deviceget;
-                    else if ($route->action == "setnewdevicekey") $result = $device->set_new_devicekey($deviceid);
                     else if ($route->action == "delete") $result = $device->delete($deviceid);
                     else if ($route->action == 'set') $result = $device->set_fields($deviceid, get('fields'));
+                    else if ($route->action == "setnewdevicekey") $result = $device->set_new_devicekey($deviceid);
                     else if ($route->action == 'template' && 
                             $route->subaction == 'init') {
                         if (isset($_GET['type'])) {

--- a/device_controller.php
+++ b/device_controller.php
@@ -85,7 +85,7 @@ function device_controller()
         else if ($route->action == "autocreate") {
             if ($session['userid']>0 && $session['write']) $result = $device->autocreate($session['userid'],get('nodeid'),get('type'));
         }
-        else if ($route->action == "template" && $route->subaction != "init") {
+        else if ($route->action == "template" && $route->subaction != "prepare" && $route->subaction != "init") {
             if ($route->subaction == "list") {
                 if ($session['userid']>0 && $session['write']) $result = $device->get_template_list_full();
             }
@@ -106,12 +106,12 @@ function device_controller()
                     else if ($route->action == "delete") $result = $device->delete($deviceid);
                     else if ($route->action == 'set') $result = $device->set_fields($deviceid, get('fields'));
                     else if ($route->action == "setnewdevicekey") $result = $device->set_new_devicekey($deviceid);
-                    else if ($route->action == 'template' && 
-                            $route->subaction == 'init') {
+                    else if ($route->action == 'template') {
                         if (isset($_GET['type'])) {
                             $device->set_fields($deviceid, json_encode(array("type"=>$_GET['type'])));
                         }
-                        $result = $device->init_template($deviceid);
+                        if ($route->subaction == 'prepare') $result = $device->prepare_template($deviceid);
+                        else if ($route->subaction == 'init') $result = $device->init_template($deviceid, get('template'));
                     }
                 }
             }

--- a/device_model.php
+++ b/device_model.php
@@ -440,11 +440,20 @@ class Device
         } else {
             return false;
         }
-    } 
+    }
 
     public function get_template_list()
     {
-        return $this->load_modules();
+        // This is called when the device view gets reloaded.
+        // Always cache and reload all templates here.
+        $this->load_template_list();
+        
+        return $this->get_template_list_meta();
+    }
+    
+    public function get_template_list_full()
+    {
+        return $this->load_template_list();
     }
 
     public function get_template_list_meta()
@@ -452,7 +461,7 @@ class Device
         $templates = array();
         
         if ($this->redis) {
-            if (!$this->redis->exists("device:template:keys")) $this->load_modules();
+            if (!$this->redis->exists("device:template:keys")) $this->load_template_list();
             
             $keys = $this->redis->sMembers("device:template:keys");
             foreach ($keys as $key)    {
@@ -463,7 +472,7 @@ class Device
         }
         else {
             if (empty($this->templates)) { // Cache it now
-                $this->load_modules();
+                $this->load_template_list();
             }
             $templates = $this->templates;
         }
@@ -492,7 +501,7 @@ class Device
         
         if ($this->redis) {
             if (!$this->redis->exists("device:template:$key")) {
-                $this->load_modules();
+                $this->load_template_list();
             }
             if ($this->redis->exists("device:template:$key")) {
                 $template = $this->redis->hGetAll("device:template:$key");
@@ -500,7 +509,7 @@ class Device
         }
         else {
             if (empty($this->templates)) { // Cache it now
-                $this->load_modules();
+                $this->load_template_list();
             }
             if (isset($this->templates[$key])) {
                 $template = $this->templates[$key];
@@ -534,7 +543,7 @@ class Device
         return array('success'=>false, 'message'=>'Unknown error while initializing device');
     }
 
-    private function load_modules()
+    private function load_template_list()
     {
         if ($this->redis) {
             $this->redis->delete("device:template:keys");

--- a/device_model.php
+++ b/device_model.php
@@ -517,8 +517,8 @@ class Device
         }
         return $template;
     }
-
-    public function init_template($id)
+    
+    public function prepare_template($id)
     {
         $id = (int) $id;
         
@@ -529,7 +529,31 @@ class Device
                 $module = $template['module'];
                 $class = $this->get_module_class($module);
                 if ($class != null) {
-                    return $class->init_template($device['userid'], $device['nodeid'], $device['name'], $device['type']);
+                    return $class->prepare_template($device);
+                }
+            }
+            return array('success'=>false, 'message'=>'Device template does not exist');
+        }
+        else {
+            return array('success'=>false, 'message'=>'Device type not specified');
+        }
+        return array('success'=>false, 'message'=>'Unknown error while preparing device initialization');
+    }
+
+    public function init_template($id, $template)
+    {
+        $id = intval($id);
+        
+        if (isset($template)) $template = json_decode($template);
+        
+        $device = $this->get($id);
+        if (isset($device['type']) && $device['type'] != 'null' && $device['type']) {
+            $meta = $this->get_template_meta($device['type']);
+            if (isset($meta)) {
+                $module = $meta['module'];
+                $class = $this->get_module_class($module);
+                if ($class != null) {
+                    return $class->init_template($device['userid'], $template);
                 }
             }
             else {


### PR DESCRIPTION
Hi again,

I recently had the motivation to tend to the idea to dry-run an initialization with possibilities to edit the template beforehand as discussed [in the forum](https://community.openenergymonitor.org/t/development-devices-inputs-and-feeds-in-emoncms/4281).

My idea there was to split the initialisation process into two steps:
Preparation and Initialisation. The preparation tends to template-specific decoding of constants, node ids or tags and checks if feeds, inputs or their defined process lists already exist or not. The prepared template will be shown in a dialog with the possibility to deselect e.g. creation of certain inputs or the overriding of existing process lists.

The modified template will then be passed to the initialisation function. Hence, inline modifications before initialising the template of e.g. feed tag names should be no big effort to be implemented with this.
To be perfectly honest, I hope this is not a bad idea as I understand that e.g. @pb66 has some quite big templates that could be bad style to be transmitted over the HTTP API as a JSON :)