### PR TITLE
Fix initialization dry-run checkbox deselection

### DIFF
--- a/Views/device_dialog.js
+++ b/Views/device_dialog.js
@@ -355,10 +355,10 @@ var device_dialog =
                 var feed = result.feeds[i];
                 var row = "";
                 if (feed.action.toLowerCase() == "none") {
-                    row += "<td><input class='input-select' type='checkbox' checked disabled /></td>";
+                    row += "<td><input row='"+i+"' class='input-select' type='checkbox' checked disabled /></td>";
                 }
                 else {
-                    row += "<td><input class='input-select' type='checkbox' checked /></td>";
+                    row += "<td><input row='"+i+"' class='input-select' type='checkbox' checked /></td>";
                 }
                 row += "<td>"+device_dialog.drawInitAction(feed.action)+"</td>"
                 row += "<td>"+feed.tag+"</td><td>"+feed.name+"</td>";
@@ -379,10 +379,10 @@ var device_dialog =
                 var input = result.inputs[i];
                 var row = "";
                 if (input.action.toLowerCase() == "none") {
-                    row += "<td><input class='input-select' type='checkbox' checked disabled /></td>";
+                    row += "<td><input row='"+i+"' class='input-select' type='checkbox' checked disabled /></td>";
                 }
                 else {
-                    row += "<td><input class='input-select' type='checkbox' checked /></td>";
+                    row += "<td><input row='"+i+"' class='input-select' type='checkbox' checked /></td>";
                 }
                 row += "<td>"+device_dialog.drawInitAction(input.action)+"</td>"
                 row += "<td>"+input.node+"</td><td>"+input.name+"</td><td>"+input.description+"</td>";
@@ -469,10 +469,8 @@ var device_dialog =
                 device_dialog.deviceTemplate.feeds.length > 0) {
             
             var feeds = device_dialog.deviceTemplate.feeds;
-            $("#device-init-feeds-table tr").find('input[type="checkbox"]:checked')
-                    .each(function (i, row) {
-                
-                template['feeds'].push(feeds[i]); 
+            $("#device-init-feeds-table tr").find('input[type="checkbox"]:checked').each(function() {
+                template['feeds'].push(feeds[$(this).attr("row")]); 
             });
         }
         
@@ -481,10 +479,8 @@ var device_dialog =
                 device_dialog.deviceTemplate.inputs.length > 0) {
             
             var inputs = device_dialog.deviceTemplate.inputs;
-            $("#device-init-inputs-table tr").find('input[type="checkbox"]:checked')
-                    .each(function (i, row) {
-                
-                template['inputs'].push(inputs[i]); 
+            $("#device-init-inputs-table tr").find('input[type="checkbox"]:checked').each(function() {
+                template['inputs'].push(inputs[$(this).attr("row")]); 
             });
         }
         

--- a/device_template.php
+++ b/device_template.php
@@ -482,7 +482,7 @@ class DeviceTemplate
             }
         }
         else if ($process->arguments->type === ProcessArg::NONE) {
-            $value = 0;
+            $value = "";
         }
         else if ($process->arguments->type === ProcessArg::TEXT) {
         }


### PR DESCRIPTION
Quick fix for the issue, described [in the forum](https://community.openenergymonitor.org/t/development-devices-inputs-and-feeds-in-emoncms/4281/103).

It actually was a pretty fundamental issue with the assignment of selected checkboxes^^

Further, I fixed a small issue with ProcessArg::NONE processes, where the processList parsing was faulty and resulted in the list to always be flagged "override"