### PR TITLE
Template init parameter as POST request and more

### DIFF
--- a/Views/device.js
+++ b/Views/device.js
@@ -1,64 +1,49 @@
 var device = {
-    'list':function()
-    {
+    'list':function() {
         var result = {};
         $.ajax({ url: path+"device/list.json", dataType: 'json', async: false, success: function(data) {result = data;} });
         return result;
     },
 
-    'get':function(id)
-    {
+    'get':function(id) {
         var result = {};
         $.ajax({ url: path+"device/get.json", data: "id="+id, async: false, success: function(data) {result = data;} });
         return result;
     },
 
-    'set':function(id, fields)
-    {
+    'set':function(id, fields) {
         var result = {};
         $.ajax({ url: path+"device/set.json", data: "id="+id+"&fields="+JSON.stringify(fields), async: false, success: function(data) {result = data;} });
         return result;
     },
 
-    'setNewDeviceKey':function(id)
-    {
+    'setNewDeviceKey':function(id) {
         var result = {};
         $.ajax({ url: path+"device/setnewdevicekey.json", data: "id="+id, async: false, success: function(data) {result = data;} });
         return result;
     },
 
-    'remove':function(id)
-    {
+    'remove':function(id) {
         var result = {};
         $.ajax({ url: path+"device/delete.json", data: "id="+id, async: false, success: function(data) {result = data;} });
         return result;
     },
 
-    'create':function(nodeid, name, description, type)
-    {
+    'create':function(nodeid, name, description, type) {
         var result = {};
         $.ajax({ url: path+"device/create.json", data: "nodeid="+nodeid+"&name="+name+"&description="+description+"&type="+type, async: false, success: function(data) {result = data;} });
         return result;
     },
 
-    'listTemplates':function()
-    {
+    'init':function(id, template) {
         var result = {};
-        $.ajax({ url: path+"device/template/list.json", dataType: 'json', async: false, success: function(data) {result = data;} });
+        $.ajax({ url: path+"device/init.json?id="+id, type: 'POST', data: "template="+JSON.stringify(template), dataType: 'json', async: false, success: function(data) {result = data;} });
         return result;
     },
 
-    'prepareTemplate':function(id)
-    {
+    'prepareTemplate':function(id) {
         var result = {};
         $.ajax({ url: path+"device/template/prepare.json", data: "id="+id, dataType: 'json', async: false, success: function(data) {result = data;} });
-        return result;
-    },
-
-    'initTemplate':function(id, template)
-    {
-        var result = {};
-        $.ajax({ url: path+"device/template/init.json?id="+id, type: 'POST', data: "template="+JSON.stringify(template), dataType: 'json', async: false, success: function(data) {result = data;} });
         return result;
     }
 }

--- a/Views/device.js
+++ b/Views/device.js
@@ -58,7 +58,7 @@ var device = {
     'initTemplate':function(id, template)
     {
         var result = {};
-        $.ajax({ url: path+"device/template/init.json", data: "id="+id+"&template="+JSON.stringify(template), dataType: 'json', async: false, success: function(data) {result = data;} });
+        $.ajax({ url: path+"device/template/init.json?id="+id, type: 'POST', data: "template="+JSON.stringify(template), dataType: 'json', async: false, success: function(data) {result = data;} });
         return result;
     }
 }

--- a/Views/device_api.php
+++ b/Views/device_api.php
@@ -42,6 +42,13 @@
     <tr><td><?php echo _('Initialize device'); ?></td><td><a href="<?php echo $path; ?>device/init.json?id=1"><?php echo $path; ?>device/init.json?id=1</a></td></tr>
 </table>
 
+<p><b><?php echo _('Device MQTT authentication'); ?></b></p>
+<table class="table">
+    <tr><td><?php echo _('Request authentication'); ?></td><td><a href="<?php echo $path; ?>device/auth/request.json"><?php echo $path; ?>device/auth/request.json</a></td></tr>
+    <tr><td><?php echo _('Check authentication request'); ?></td><td><a href="<?php echo $path; ?>device/auth/check.json"><?php echo $path; ?>device/auth/check.json</a></td></tr>
+    <tr><td><?php echo _('Allow authentication request'); ?></td><td><a href="<?php echo $path; ?>device/auth/allow.json?ip=127.0.0.1"><?php echo $path; ?>device/auth/allow.json?ip=127.0.0.1</a></td></tr>
+</table>
+
 <p><b><?php echo _('Template actions'); ?></b></p>
 <table class="table">
     <tr><td><?php echo _('List templates'); ?></td><td><a href="<?php echo $path; ?>device/template/list.json"><?php echo $path; ?>device/template/list.json</a></td></tr>

--- a/Views/device_api.php
+++ b/Views/device_api.php
@@ -39,15 +39,15 @@
     <tr><td><?php echo _('Add a device'); ?></td><td><a href="<?php echo $path; ?>device/create.json?nodeid=Test&name=Test"><?php echo $path; ?>device/create.json?nodeid=Test&name=Test</a></td></tr>
     <tr><td><?php echo _('Delete device'); ?></td><td><a href="<?php echo $path; ?>device/delete.json?id=1"><?php echo $path; ?>device/delete.json?id=1</a></td></tr>
     <tr><td><?php echo _('Update device'); ?></td><td><a href="<?php echo $path; ?>device/set.json?id=1&fields={%22name%22:%22Test%22,%22description%22:%22Room%22,%22nodeid%22:%22House%22,%22type%22:%22test%22}"><?php echo $path; ?>device/set.json?id=1&fields={"name":"Test","description":"Room","nodeid":"House","type":"test"}</a></td></tr>
+    <tr><td><?php echo _('Initialize device'); ?></td><td><a href="<?php echo $path; ?>device/init.json?id=1"><?php echo $path; ?>device/init.json?id=1</a></td></tr>
 </table>
 
 <p><b><?php echo _('Template actions'); ?></b></p>
 <table class="table">
     <tr><td><?php echo _('List templates'); ?></td><td><a href="<?php echo $path; ?>device/template/list.json"><?php echo $path; ?>device/template/list.json</a></td></tr>
     <tr><td><?php echo _('List templates short'); ?></td><td><a href="<?php echo $path; ?>device/template/listshort.json"><?php echo $path; ?>device/template/listshort.json</a></td></tr>
-    <tr><td><?php echo _('get template details'); ?></td><td><a href="<?php echo $path; ?>device/template/get.json?device=example"><?php echo $path; ?>device/template/get.json?device=example</a></td></tr>
+    <tr><td><?php echo _('get template details'); ?></td><td><a href="<?php echo $path; ?>device/template/get.json?type=example"><?php echo $path; ?>device/template/get.json?type=example</a></td></tr>
     <tr><td><?php echo _('Prepare device initialization'); ?></td><td><a href="<?php echo $path; ?>device/template/prepare.json?id=1"><?php echo $path; ?>device/template/prepare.json?id=1</a></td></tr>
-    <tr><td><?php echo _('Initialize device'); ?></td><td><a href="<?php echo $path; ?>device/template/init.json?id=1"><?php echo $path; ?>device/template/init.json?id=1</a></td></tr>
 </table>
 
 <a class="anchor" id="expression"></a> 
@@ -55,7 +55,3 @@
 <p><?php echo _('Template files are located at <b>\'\\Modules\\device\\data\\*.json\'</b>'); ?></p>
 <p><?php echo _('Each file defines a device type and provides the default inputs and feeds configurations for that device.'); ?></p>
 <p><?php echo _('A device should only need to be initialized once on instalation. Initiating a device twice will duplicate its default inputs and feeds.'); ?></p>
-
-
-
-

--- a/Views/device_dialog.js
+++ b/Views/device_dialog.js
@@ -4,7 +4,7 @@ var device_dialog =
     deviceTemplate: null,
     deviceType: null,
     device: null,
-    
+
     'loadConfig':function(templates, device) {
         this.templates = templates;
         
@@ -20,9 +20,6 @@ var device_dialog =
         }
         
         this.drawConfig();
-        
-        // Initialize callbacks
-        this.registerConfigEvents();
     },
 
     'drawConfig':function() {
@@ -91,8 +88,8 @@ var device_dialog =
                         name = name.substr(0, 25) + "...";
                     }
                     
-                    out += "<tr class='group-row' type='"+id+"' style='cursor:pointer'>";
-                    out += "<td>"+name+"</td>";
+                    out += "<tr class='group-row' type='"+id+"'>";
+                    out += "<td style='padding-left:24px; cursor:pointer'>"+name+"</td>";
                     out += "</tr>";
                 }
                 out += "</tbody>";    
@@ -104,7 +101,7 @@ var device_dialog =
             if (this.templates[this.deviceType]!=undefined) {
                 var template = this.templates[this.deviceType]
                 
-                $(".category-body[category='"+template.category+"']").show();
+                $(".group-header[category='"+template.category+"']").show();
                 $(".group-body[category='"+template.category+"'][group='"+template.group+"']").show();
                 $(".group-row[type='"+this.deviceType+"']").addClass("device-selected");
                 
@@ -112,6 +109,9 @@ var device_dialog =
                 $('#template-info').show();
             }
         }
+        
+        // Initialize callbacks
+        this.registerConfigEvents();
     },
 
     'clearConfigModal':function() {
@@ -130,7 +130,7 @@ var device_dialog =
             $('#device-config-description').val(this.device.description);
             $('#device-config-devicekey').val(this.device.devicekey).prop("disabled", false);
             $("#device-config-devicekey-new").prop("disabled", false);
-            $('#device-config-delete').show();
+            $('#device-delete').show();
             $("#device-init").show();
             $("#device-save").html("Save");
         }
@@ -140,10 +140,11 @@ var device_dialog =
             $('#device-config-description').val('');
             $('#device-config-devicekey').val('').prop("disabled", true);
             $("#device-config-devicekey-new").prop("disabled", true);
-            $('#device-config-delete').hide();
+            $('#device-delete').hide();
             $("#device-init").hide();
             $("#device-save").html("Save & Initialize");
         }
+        device_dialog.drawTemplate();
     },
 
     'adjustConfigModal':function() {
@@ -233,10 +234,13 @@ var device_dialog =
             }
             else {
                 device_dialog.deviceType = null;
+                
                 $('#template-description').text('');
                 $('#template-info').hide();
                 $("#device-init").show()
             }
+            
+            device_dialog.drawTemplate();
         });
 
         $("#sidebar-open").off('click').on('click', function () {
@@ -304,7 +308,7 @@ var device_dialog =
                 return false;
             }
         });
-
+        
         $("#device-delete").off('click').on('click', function () {
             $('#device-config-modal').modal('hide');
             device_dialog.loadDelete(device_dialog.device, null);
@@ -318,8 +322,19 @@ var device_dialog =
         $("#device-config-devicekey-new").off('click').on('click', function () {
             device_dialog.device.devicekey = device.setNewDeviceKey(device_dialog.device.id);
             $('#device-config-devicekey').val(device_dialog.device.devicekey);
-        });        
-        
+        });
+    },
+
+    'drawTemplate':function() {
+        if (this.deviceType !== null && this.deviceType in this.templates) {
+            var template = this.templates[this.deviceType];
+            $('#template-description').html('<em style="color:#888">'+template.description+'</em>');
+            $('#template-info').show();
+        }
+        else {
+            $('#template-description').text('');
+            $('#template-info').hide();
+        }
     },
 
     'loadInit': function() {
@@ -336,7 +351,7 @@ var device_dialog =
             $('#device-init-modal').modal('hide');
             
             var template = device_dialog.parseTemplate();
-            var result = device.initTemplate(device_dialog.device.id, template);
+            var result = device.init(device_dialog.device.id, template);
             if (typeof result.success !== 'undefined' && !result.success) {
                 alert('Unable to initialize device:\n'+result.message);
                 return false;
@@ -463,7 +478,7 @@ var device_dialog =
 
     'parseTemplate': function() {
         var template = {};
-
+        
         template['feeds'] = [];
         if (typeof device_dialog.deviceTemplate.feeds !== 'undefined' && 
                 device_dialog.deviceTemplate.feeds.length > 0) {
@@ -489,7 +504,7 @@ var device_dialog =
 
     'loadDelete': function(device, tablerow) {
         this.device = device;
-
+        
         $('#device-delete-modal').modal('show');
         $('#device-delete-modal-label').html('Delete Device: <b>'+device.name+'</b>');
         

--- a/Views/device_dialog.php
+++ b/Views/device_dialog.php
@@ -2,7 +2,7 @@
     global $path;
 ?>
 
-<script type="text/javascript" src="<?php echo $path; ?>Modules/device/Views/device_dialog.js?v=3"></script>
+<script type="text/javascript" src="<?php echo $path; ?>Modules/device/Views/device_dialog.js"></script>
 
 <style>
     .group-body tr:hover > td {
@@ -22,22 +22,30 @@
 
     .modal-adjust .modal-body {
         max-height: none;
-        overflow-y: auto;
+        overflow-y: hidden;
     }
 
     #sidebar-wrapper {
         position: absolute;
-        margin: -15px;
-        width: 250px;
+        margin-top: -15px;
+        margin-left: -15px;
+        max-height: none;
         height: 100%;
-        background: #eee;
+        width: 250px;
         overflow-y: auto;
+        background-color: #eee;
         z-index: 1000;
     }
 
     #content-wrapper {
+        position: absolute;
+        right: 15px;
+        left: 15px;
         margin-top: -15px;
         margin-left: 250px;
+        height: 100%;
+        max-height: none;
+        overflow-y: auto;
     }
 
     #content-wrapper .divider {
@@ -53,21 +61,19 @@
     #template-info .tooltip-inner {
         max-width: 500px;
     }
-    
-    input[type="checkbox"] { margin:0px; }
-    
+
     #device-init-modal {
-        width: 50%; left:25%; /* (100%-width)/2 */
+        width: 60%; left:20%; /* (100%-width)/2 */
         margin-left: auto; margin-right: auto;
     }
-    
+
     #device-init-modal table td { text-align: left; }
-    
+
     #device-init-feeds table td:nth-of-type(1) { width:14px; text-align: center; }
     #device-init-feeds table td:nth-of-type(2) { width:5%; }
     #device-init-feeds table td:nth-of-type(3) { width:15%; }
     #device-init-feeds table td:nth-of-type(4) { width:25%; }
-    
+
     #device-init-inputs table td:nth-of-type(1) { width:14px; text-align: center; }
     #device-init-inputs table td:nth-of-type(2) { width:5%; }
     #device-init-inputs table td:nth-of-type(3) { width:5%; }
@@ -93,19 +99,19 @@
         
         <div id="content-wrapper" style="max-width:1280px">
             
-            <h3>Configuration</h3>
+            <h3><?php echo _('Configuration'); ?></h3>
             
             <div id="navigation" style="padding-bottom:5px;">
                 <button class="btn" id="sidebar-open"><i class="icon-list"></i></button>
             </div>
-
+            
             <span id="template-info" style="display:none;">
                 <span id="template-description"></span>
                 <span id="template-tooltip" data-toggle="tooltip" data-placement="bottom">
                     <i class="icon-info-sign" style="cursor:pointer; padding-left:6px;"></i>
                 </span>
             </span>
-
+            
             <div class="divider"></div>
             
             <label><b><?php echo _('Node'); ?></b></label>
@@ -113,14 +119,14 @@
             
             <label><b><?php echo _('Name'); ?></b></label>
             <input id="device-config-name" class="input-large" type="text">
-             
+            
             <label><b><?php echo _('Location'); ?></b></label>
             <input id="device-config-description" class="input-large" type="text">
             
             <label><b><?php echo _('Device Key'); ?></b></label>
             <div class="input-append">
                 <input id="device-config-devicekey" class="input-large" type="text" style="width:260px">
-                <button id="device-config-devicekey-new" class="btn">New</button>
+                <button id="device-config-devicekey-new" class="btn"><?php echo _('New'); ?></button>
             </div>
         </div>
     </div>

--- a/Views/device_view.php
+++ b/Views/device_view.php
@@ -51,7 +51,7 @@
 
 <script>
   var path = "<?php echo $path; ?>";
-  var devices = <?php echo json_encode($devices); ?>;
+  var devices = <?php echo json_encode($templates); ?>;
   
   // Extend table library field types
   for (z in customtablefields) table.fieldtypes[z] = customtablefields[z];

--- a/data/Control/openevse.json
+++ b/data/Control/openevse.json
@@ -1,27 +1,27 @@
 {
-	"name": "openevse",
+	"name": "OpenEVSE",
 	"category": "Control",
-	"group": "control",
-    "description": "openevse",
+	"group": "MQTT",
+    "description": "OpenEVSE control",
     "inputs": [
         {
             "name": "period",
-            "description": "period",
+            "description": "Control period",
             "processList": []
         },
         {
             "name": "end",
-            "description": "end",
+            "description": "Control end",
             "processList": []
         },
         {
             "name": "interruptible",
-            "description": "interruptible",
+            "description": "Control interruptible",
             "processList": []
         },
         {
             "name": "status",
-            "description": "status",
+            "description": "Control status",
             "processList": []
         }
     ],

--- a/data/Control/smartplug.json
+++ b/data/Control/smartplug.json
@@ -1,33 +1,33 @@
 {
-	"name": "smartplug",
+	"name": "Smartplug",
 	"category": "Control",
-	"group": "control",
-    "description": "smartplug",
+	"group": "MQTT",
+    "description": "Smartplug control",
     "inputs": [
         {
             "name": "period",
-            "description": "period",
+            "description": "Control period",
             "processList": []
         },
         {
             "name": "end",
-            "description": "end",
+            "description": "Control end",
             "processList": []
         },
         {
             "name": "interruptible",
-            "description": "interruptible",
+            "description": "Control interruptible",
             "processList": []
         },
         {
             "name": "status",
-            "description": "status",
+            "description": "Control status",
             "processList": []
         }
     ],
 
     "feeds": [],
-    
+
     "control": 
     {
         "active": {"name":"Active","type":"checkbox","default":1},

--- a/data/Control/wifirelay.json
+++ b/data/Control/wifirelay.json
@@ -1,27 +1,27 @@
 {
-	"name": "wifirelay",
+	"name": "Wi-Fi relay",
 	"category": "Control",
-	"group": "control",
-    "description": "wifirelay",
+	"group": "MQTT",
+    "description": "Wi-Fi relay control",
     "inputs": [
         {
             "name": "period",
-            "description": "period",
+            "description": "Control period",
             "processList": []
         },
         {
             "name": "end",
-            "description": "end",
+            "description": "Control end",
             "processList": []
         },
         {
             "name": "interruptible",
-            "description": "interruptible",
+            "description": "Control interruptible",
             "processList": []
         },
         {
             "name": "status",
-            "description": "status",
+            "description": "Control status",
             "processList": []
         }
     ],

--- a/device_controller.php
+++ b/device_controller.php
@@ -111,7 +111,7 @@ function device_controller()
                             $device->set_fields($deviceid, json_encode(array("type"=>$_GET['type'])));
                         }
                         if ($route->subaction == 'prepare') $result = $device->prepare_template($deviceid);
-                        else if ($route->subaction == 'init') $result = $device->init_template($deviceid, get('template'));
+                        else if ($route->subaction == 'init') $result = $device->init_template($deviceget, $_POST['template']);
                     }
                 }
             }

--- a/device_model.php
+++ b/device_model.php
@@ -13,19 +13,22 @@ defined('EMONCMS_EXEC') or die('Restricted access');
 
 class Device
 {
+    const TEMPLATE = 'template';
+
     public $mysqli;
     public $redis;
     private $log;
 
-    public function __construct($mysqli,$redis)
-    {
+    private $templates;
+
+    public function __construct($mysqli, $redis) {
         $this->mysqli = $mysqli;
         $this->redis = $redis;
+        $this->templates = array();
         $this->log = new EmonLogger(__FILE__);
     }
 
-    public function devicekey_session($devicekey)
-    {
+    public function devicekey_session($devicekey) {
         // 1. Only allow alphanumeric characters
         // if (!ctype_alnum($devicekey)) return array();
         
@@ -38,8 +41,7 @@ class Device
         //----------------------------------------------------
         // Check for devicekey login
         //----------------------------------------------------
-        if($this->redis && $this->redis->exists("device:key:$devicekey"))
-        {
+        if($this->redis && $this->redis->exists("device:key:$devicekey")) {
             $session['userid'] = $this->redis->get("device:key:$devicekey:user");
             $session['read'] = 0;
             $session['write'] = 1;
@@ -50,8 +52,7 @@ class Device
             $session['nodeid'] = $this->redis->get("device:key:$devicekey:node");
             $this->redis->hMset("device:lastvalue:".$session['device'], array('time' => $time));
         }
-        else
-        {
+        else {
             $stmt = $this->mysqli->prepare("SELECT id, userid, nodeid FROM device WHERE devicekey=?");
             $stmt->bind_param("s",$devicekey);
             $stmt->execute();
@@ -84,8 +85,7 @@ class Device
         return $session;
     }
 
-    public function exist($id)
-    {
+    public function exist($id) {
         static $device_exists_cache = array(); // Array to hold the cache
         if (isset($device_exists_cache[$id])) {
             $device_exist = $device_exists_cache[$id]; // Retrieve from static cache
@@ -112,9 +112,8 @@ class Device
         return $device_exist;
     }
 
-    public function exists_name($userid, $name)
-    {
-        $userid = (int) $userid;
+    public function exists_name($userid, $name) {
+        $userid = intval($userid);
         $name = preg_replace('/[^\p{L}_\p{N}\s-:]/u','',$name);
         
         $stmt = $this->mysqli->prepare("SELECT id FROM device WHERE userid=? AND name=?");
@@ -127,9 +126,8 @@ class Device
         if ($result && $id>0) return $id; else return false;
     }
 
-    public function exists_nodeid($userid,$nodeid)
-    {
-        $userid = (int) $userid;
+    public function exists_nodeid($userid, $nodeid) {
+        $userid = intval($userid);
         $nodeid = preg_replace('/[^\p{L}_\p{N}\s-:]/u','',$nodeid);
 
         $stmt = $this->mysqli->prepare("SELECT id FROM device WHERE userid=? AND nodeid=?");
@@ -142,11 +140,12 @@ class Device
         if ($result && $id>0) return $id; else return false;
     }
 
-    public function get($id)
-    {
-        $id = (int) $id;
-        if (!$this->exist($id) && !$this->load_device_to_redis($id)) {
-            return array('success'=>false, 'message'=>'Device does not exist');
+    public function get($id) {
+        $id = intval($id);
+        if (!$this->exist($id)) {
+            if (!$this->redis || !$this->load_device_to_redis($id)) {
+                return array('success'=>false, 'message'=>'Device does not exist');
+            }
         }
         
         if ($this->redis) {
@@ -167,8 +166,7 @@ class Device
         return $device;
     }
 
-    public function get_list($userid)
-    {
+    public function get_list($userid) {
         if ($this->redis) {
             return $this->get_list_redis($userid);
         } else {
@@ -176,9 +174,8 @@ class Device
         }
     }
 
-    private function get_list_redis($userid)
-    {
-        $userid = (int) $userid;
+    private function get_list_redis($userid) {
+        $userid = intval($userid);
         
         if (!$this->redis->exists("user:device:$userid")) {
             $this->log->info("Load devices to redis in get_list_redis");
@@ -187,8 +184,7 @@ class Device
 
         $devices = array();
         $deviceids = $this->redis->sMembers("user:device:$userid");
-        foreach ($deviceids as $id)
-        {
+        foreach ($deviceids as $id) {
             $device = $this->redis->hGetAll("device:$id");
             // Verify, if the cached device contains the userid, to avoid compatibility issues
             // with former versions where the userid was not cached.
@@ -201,24 +197,23 @@ class Device
         return $devices;
     }
 
-    private function get_list_mysql($userid)
-    {
-        $userid = (int) $userid;
+    private function get_list_mysql($userid) {
+        $userid = intval($userid);
         
         $devices = array();
-        $result = $this->mysqli->query("SELECT `id`, `userid`, `nodeid`, `name`, `description`, `type`, `devicekey`, `time` FROM device WHERE userid = '$userid' ORDER BY nodeid, name asc");
-        while ($row = (array) $result->fetch_object()) $devices[] = $row;
-        
+        $result = $this->mysqli->query("SELECT `id`,`userid`,`nodeid`,`name`,`description`,`type`,`devicekey`,`time` FROM device WHERE userid = '$userid' ORDER BY nodeid, name asc");
+        while ($device = (array) $result->fetch_object()) {
+            $devices[] = $device;
+        }
         return $devices;
     }
 
-    private function load_list_to_redis($userid)
-    {
-        $userid = (int) $userid;
+    private function load_list_to_redis($userid) {
+        $userid = intval($userid);
+        
         $this->redis->delete("user:device:$userid");
-        $result = $this->mysqli->query("SELECT `id`, `userid`, `nodeid`, `name`, `description`, `type`, `devicekey` FROM device WHERE userid = '$userid' ORDER BY nodeid, name asc");
-        while ($row = $result->fetch_object())
-        {
+        $result = $this->mysqli->query("SELECT `id`,`userid`,`nodeid`,`name`,`description`,`type`,`devicekey` FROM device WHERE userid = '$userid' ORDER BY nodeid, name asc");
+        while ($row = $result->fetch_object()) {
             $this->redis->sAdd("user:device:$userid", $row->id);
             $this->redis->hMSet("device:".$row->id, array(
                 'id'=>$row->id,
@@ -232,9 +227,9 @@ class Device
         }
     }
 
-    private function load_device_to_redis($id)
-    {
-        $id = (int) $id;
+    private function load_device_to_redis($id) {
+        $id = intval($id);
+
         $result = $this->mysqli->query("SELECT `userid` FROM device WHERE id = '$id'");
         if ($result->num_rows>0) {
             $row = $result->fetch_object();
@@ -243,9 +238,8 @@ class Device
         return false;
     }
 
-    public function autocreate($userid, $_nodeid, $_type)
-    {
-        $userid = (int) $userid;
+    public function autocreate($userid, $_nodeid, $_type) {
+        $userid = intval($userid);
         
         $nodeid = preg_replace('/[^\p{L}_\p{N}\s-:]/u','',$_nodeid);
         if ($_nodeid != $nodeid) return array("success"=>false, "message"=>"Invalid nodeid");
@@ -270,10 +264,8 @@ class Device
         }
     }
 
-    public function create($userid, $nodeid, $name, $description, $type)
-    {
-        $userid = (int) $userid;
-        
+    public function create($userid, $nodeid, $name, $description, $type) {
+        $userid = intval($userid);
         $nodeid = preg_replace('/[^\p{L}_\p{N}\s-:]/u', '', $nodeid);
         
         if (isset($name)) {
@@ -283,13 +275,13 @@ class Device
         }
         
         if (isset($description)) {
-            $description= preg_replace('/[^\p{L}_\p{N}\s-:]/u', '', $description);
+            $description = preg_replace('/[^\p{L}_\p{N}\s-:]/u', '', $description);
         } else {
             $description = '';
         }
         
         if (isset($type)) {
-            $type= preg_replace('/[^\p{L}_\p{N}\s-:]/u', '', $type);
+            $type = preg_replace('/[^\/\|\,\w\s-:]/','', $type);
         } else {
             $type = '';
         }
@@ -312,15 +304,18 @@ class Device
                 }
                 return $deviceid;
             }
-            else return array('success'=>false, 'result'=>"SQL returned invalid insert feed id");
+            return array('success'=>false, 'result'=>"SQL returned invalid insert feed id");
         }
-        else return array('success'=>false, 'message'=>'Device already exists');
+        return array('success'=>false, 'message'=>'Device already exists');
     }
 
-    public function delete($id)
-    {
-        $id = (int) $id;
-        if (!$this->exist($id)) return array('success'=>false, 'message'=>'Device does not exist');
+    public function delete($id) {
+        $id = intval($id);
+        if (!$this->exist($id)) {
+            if (!$this->redis || !$this->load_device_to_redis($id)) {
+                return array('success'=>false, 'message'=>'Device does not exist');
+            }
+        }
         
         if ($this->redis) {
             $result = $this->mysqli->query("SELECT userid FROM device WHERE `id` = '$id'");
@@ -332,20 +327,23 @@ class Device
         
         if ($this->redis) {
             if (isset($row['userid']) && $row['userid']) {
-                $this->redis->delete("device:".$id);
+                $this->redis->delete("device:$id");
                 $this->log->info("Load devices to redis in delete");
                 $this->load_list_to_redis($row['userid']);
             }
         }
     }
 
-    public function set_fields($id,$fields)
-    {
-        $id = (int) $id;
-        if (!$this->exist($id)) return array('success'=>false, 'message'=>'Device does not exist');
-        $fields = json_decode(stripslashes($fields));
-        
+    public function set_fields($id, $fields) {
+        $id = intval($id);
+        if (!$this->exist($id)) {
+            if (!$this->redis || !$this->load_device_to_redis($id)) {
+                return array('success'=>false, 'message'=>'Device does not exist');
+            }
+        }
         $success = true;
+        
+        $fields = json_decode(stripslashes($fields));
 
         if (isset($fields->name)) {
             if (preg_replace('/[^\p{N}\p{L}_\s-:]/u','',$fields->name)!=$fields->name) return array('success'=>false, 'message'=>'invalid characters in device name');
@@ -376,7 +374,7 @@ class Device
             } else $success = false;
             $stmt->close();
         }
-
+        
         if (isset($fields->type)) {
             if (preg_replace('/[^\/\|\,\w\s-:]/','',$fields->type)!=$fields->type) return array('success'=>false, 'message'=>'invalid characters in device type');
             $stmt = $this->mysqli->prepare("UPDATE device SET type = ? WHERE id = ?");
@@ -402,17 +400,20 @@ class Device
             $stmt->close();
         }
 
-        if ($success){
+        if ($success) {
             return array('success'=>true, 'message'=>'Field updated');
         } else {
             return array('success'=>false, 'message'=>'Field could not be updated');
         }
     }
     
-    public function set_new_devicekey($id)
-    {
-        $id = (int) $id;
-        if (!$this->exist($id)) return array('success'=>false, 'message'=>'Device does not exist');
+    public function set_new_devicekey($id) {
+        $id = intval($id);
+        if (!$this->exist($id)) {
+            if (!$this->redis || !$this->load_device_to_redis($id)) {
+                return array('success'=>false, 'message'=>'Device does not exist');
+            }
+        }
         
         $devicekey = md5(uniqid(mt_rand(), true));
         
@@ -429,51 +430,51 @@ class Device
         }
     }
 
-    public function get_template_list()
-    {
+    public function get_template_list($userid) {
         // This is called when the device view gets reloaded.
         // Always cache and reload all templates here.
-        $this->load_template_list();
+        $this->load_template_list($userid);
         
-        return $this->get_template_list_meta();
-    }
-    
-    public function get_template_list_full()
-    {
-        return $this->load_template_list();
+        return $this->get_template_list_meta($userid);
     }
 
-    public function get_template_list_meta()
-    {
+    public function get_template_list_full($userid) {
+        return $this->load_template_list($userid);
+    }
+
+    public function get_template_list_meta($userid) {
         $templates = array();
         
         if ($this->redis) {
-            if (!$this->redis->exists("device:template:keys")) $this->load_template_list();
+            if (!$this->redis->exists("device:template:meta")) $this->load_template_list();
             
-            $keys = $this->redis->sMembers("device:template:keys");
-            foreach ($keys as $key)    {
-                $template = $this->redis->hGetAll("device:template:$key");
+            $ids = $this->redis->sMembers("device:template:meta");
+            foreach ($ids as $id) {
+                $template = $this->redis->hGetAll("device:template:$id");
                 $template["control"] = (bool) $template["control"];
-                $templates[$key] = $template;
+                
+                $templates[$id] = $template;
             }
         }
         else {
             if (empty($this->templates)) { // Cache it now
-                $this->load_template_list();
+                $this->load_template_list($userid);
             }
             $templates = $this->templates;
         }
+        ksort($templates);
         return $templates;
     }
 
-    public function get_template($key)
-    {
-        $template = $this->get_template_meta($key);
+    public function get_template($userid, $id) {
+        $userid = intval($userid);
+        
+        $template = $this->get_template_meta($userid, $id);
         if (isset($template)) {
             $module = $template['module'];
-            $class = $this->get_module_class($module);
+            $class = $this->get_module_class($module, self::TEMPLATE);
             if ($class != null) {
-                return $class->get_template($key);
+                return $class->get_template($userid, $id);
             }
         }
         else {
@@ -482,42 +483,41 @@ class Device
         return array('success'=>false, 'message'=>'Unknown error while loading device template details');
     }
 
-    private function get_template_meta($key)
-    {
+    private function get_template_meta($userid, $id) {
         $template = null;
         
         if ($this->redis) {
-            if (!$this->redis->exists("device:template:$key")) {
-                $this->load_template_list();
+            if (!$this->redis->exists("device:template:$id")) {
+                $this->load_template_list($userid);
             }
-            if ($this->redis->exists("device:template:$key")) {
-                $template = $this->redis->hGetAll("device:template:$key");
+            if ($this->redis->exists("device:template:$id")) {
+                $template = $this->redis->hGetAll("device:template:$id");
             }
         }
         else {
             if (empty($this->templates)) { // Cache it now
-                $this->load_template_list();
+                $this->load_template_list($userid);
             }
-            if (isset($this->templates[$key])) {
-                $template = $this->templates[$key];
+            if (isset($this->templates[$id])) {
+                $template = $this->templates[$id];
             }
         }
         return $template;
     }
-    
-    public function prepare_template($id)
-    {
-        $id = (int) $id;
+
+    public function prepare_template($id) {
+        $id = intval($id);
         
         $device = $this->get($id);
         if (isset($device['type']) && $device['type'] != 'null' && $device['type']) {
-            $template = $this->get_template_meta($device['type']);
+            $template = $this->get_template_meta($device['userid'], $device['type']);
             if (isset($template)) {
                 $module = $template['module'];
-                $class = $this->get_module_class($module);
+                $class = $this->get_module_class($module, self::TEMPLATE);
                 if ($class != null) {
                     return $class->prepare_template($device);
                 }
+                return array('success'=>false, 'message'=>'Device template class is not defined');
             }
             return array('success'=>false, 'message'=>'Device template does not exist');
         }
@@ -527,37 +527,43 @@ class Device
         return array('success'=>false, 'message'=>'Unknown error while preparing device initialization');
     }
 
-    public function init_template($id, $template)
-    {
+    public function init($id, $template) {
         $id = intval($id);
         
+        $device = $this->get($id);
+        $result = $this->init_template($device, $template);
+        if (isset($result) && !$result['success']) {
+            return $result;
+        }
+        return array('success'=>true, 'message'=>'Device initialized');
+    }
+
+    public function init_template($device, $template) {
         if (isset($template)) $template = json_decode($template);
         
-        $device = $this->get($id);
         if (isset($device['type']) && $device['type'] != 'null' && $device['type']) {
-            $meta = $this->get_template_meta($device['type']);
+            $meta = $this->get_template_meta($device['userid'], $device['type']);
             if (isset($meta)) {
                 $module = $meta['module'];
-                $class = $this->get_module_class($module);
+                $class = $this->get_module_class($module, self::TEMPLATE);
                 if ($class != null) {
-                    return $class->init_template($device['userid'], $template);
+                    return $class->init_template($device, $template);
                 }
+                return array('success'=>false, 'message'=>'Device template class is not defined');
             }
-            else {
-                return array('success'=>false, 'message'=>'Device template does not exist');
-            }
+            return array('success'=>false, 'message'=>'Device template does not exist');
         }
         else {
             return array('success'=>false, 'message'=>'Device type not specified');
         }
-        
         return array('success'=>false, 'message'=>'Unknown error while initializing device');
     }
 
-    private function load_template_list()
-    {
+    private function load_template_list($userid) {
+        $userid = intval($userid);
+        
         if ($this->redis) {
-            $this->redis->delete("device:template:keys");
+            $this->redis->delete("device:template:meta");
         }
         else {
             $this->templates = array();
@@ -567,9 +573,9 @@ class Device
         $dir = scandir("Modules");
         for ($i=2; $i<count($dir); $i++) {
             if (filetype("Modules/".$dir[$i])=='dir' || filetype("Modules/".$dir[$i])=='link') {
-                $class = $this->get_module_class($dir[$i]);
+                $class = $this->get_module_class($dir[$i], self::TEMPLATE);
                 if ($class != null) {
-                    $module_templates = $class->get_template_list();
+                    $module_templates = $class->get_template_list($userid);
                     foreach($module_templates as $key => $value) {
                         $this->cache_template($dir[$i], $key, $value);
                         $templates[$key] = $value;
@@ -581,42 +587,40 @@ class Device
         return $templates;
     }
 
-    private function get_module_class($module)
-    {
-        /*
-         magic function __call (above) MUST BE USED with this.
-         Load additional template module files.
-         Looks in the folder Modules/modulename/ for a file modulename_template.php
-         (module_name all lowercase but class ModulenameTemplate in php file that is CamelCase)
-         */
-        $module_file = "Modules/".$module."/".$module."_template.php";
-        $module_class = null;
-        if(file_exists($module_file)){
-            require_once($module_file);
-            
-            $module_class_name = ucfirst(strtolower($module)."Template");
-            $module_class = new $module_class_name($this);
-        }
-        return $module_class;
-    }
-
-    private function cache_template($module, $key, $template)
-    {
+    private function cache_template($module, $id, $template) {
         $meta = array(
             "module"=>$module
         );
-        $meta["name"] = ((!isset($template->name) || $template->name == "" ) ? $key : $template->name);
+        $meta["name"] = ((!isset($template->name) || $template->name == "" ) ? $id : $template->name);
         $meta["category"] = ((!isset($template->category) || $template->category== "" ) ? "General" : $template->category);
         $meta["group"] = ((!isset($template->group) || $template->group== "" ) ? "Miscellaneous" : $template->group);
         $meta["description"] = (!isset($template->description) ? "" : $template->description);
         $meta["control"] = (!isset($template->control) ? false : true);
         
         if ($this->redis) {
-            $this->redis->sAdd("device:template:keys", $key);
-            $this->redis->hMSet("device:template:$key", $meta);
+            $this->redis->sAdd("device:template:meta", $id);
+            $this->redis->hMSet("device:template:$id", $meta);
         }
         else {
-            $this->templates[$key] = $meta;
+            $this->templates[$id] = $meta;
         }
+    }
+
+    private function get_module_class($module, $type) {
+        /*
+         magic function __call (above) MUST BE USED with this.
+         Load additional template module files.
+         Looks in the folder Modules/modulename/ for a file modulename_template.php
+         (module_name all lowercase but class ModulenameTemplate in php file that is CamelCase)
+         */
+        $module_file = "Modules/".$module."/".$module."_".$type.".php";
+        $module_class = null;
+        if(file_exists($module_file)){
+            require_once($module_file);
+            
+            $module_class_name = ucfirst(strtolower($module)).ucfirst($type);
+            $module_class = new $module_class_name($this);
+        }
+        return $module_class;
     }
 }

--- a/device_template.php
+++ b/device_template.php
@@ -89,13 +89,14 @@ class DeviceTemplate
         
         $userid = intval($userid);
         
-        if (!is_object($template)) {
+        if (empty($template)) {
             $result = $this->prepare_template($device);
             if (isset($result["success"]) && !$result["success"]) {
                 return $result;
             }
             $template = $result;
         }
+        if (!is_object($template)) $template = (object) $template;
         
         if (isset($template->feeds)) {
             $feeds = $template->feeds;

--- a/device_template.php
+++ b/device_template.php
@@ -24,11 +24,11 @@ class DeviceTemplate
         $this->log = new EmonLogger(__FILE__);
     }
 
-    public function get_template_list() {
-        return $this->load_template_list();
+    public function get_template_list($userid) {
+        return $this->load_template_list($userid);
     }
 
-    protected function load_template_list() {
+    protected function load_template_list($userid) {
         $list = array();        
         
         $iti = new RecursiveDirectoryIterator("Modules/device/data");
@@ -41,27 +41,27 @@ class DeviceTemplate
         return $list;
     }
 
-    public function get_template($type) {
+    public function get_template($userid, $type) {
         $type = preg_replace('/[^\p{L}_\p{N}\s-:]/u','', $type);
-        $list = $this->load_template_list();
+        $list = $this->load_template_list($userid);
         if (!isset($list[$type])) {
             return array('success'=>false, 'message'=>'Device template "'.$type.'" not found');
         }
         return $list[$type];
     }
-    
+
     public function prepare_template($device) {
-        
         $userid = intval($device['userid']);
         
-        $result = $this->get_template($device['type']);
+        $result = $this->get_template($userid, $device['type']);
         if (!is_object($result)) {
             return $result;
         }
+        $prefix = $this->parse_prefix($device['nodeid'], $device['name'], $result);
         
         if (isset($result->feeds)) {
             $feeds = $result->feeds;
-            $this->prepare_feeds($userid, $device['nodeid'], $feeds);
+            $this->prepare_feeds($userid, $device['nodeid'], $prefix, $feeds);
         }
         else {
             $feeds = [];
@@ -69,25 +69,24 @@ class DeviceTemplate
         
         if (isset($result->inputs)) {
             $inputs = $result->inputs;
-            $this->prepare_inputs($userid, $device['nodeid'], $inputs);
+            $this->prepare_inputs($userid, $device['nodeid'], $prefix, $inputs);
         }
         else {
             $inputs = [];
         }
         
         if (!empty($feeds)) {
-            $this->prepare_input_processes($userid, $feeds, $inputs);
+            $this->prepare_input_processes($userid, $prefix, $feeds, $inputs);
         }
         if (!empty($inputs)) {
-            $this->prepare_feed_processes($userid, $feeds, $inputs);
+            $this->prepare_feed_processes($userid, $prefix, $feeds, $inputs);
         }
         
         return array('success'=>true, 'feeds'=>$feeds, 'inputs'=>$inputs);
     }
 
-    public function init_template($userid, $template) {
-        
-        $userid = intval($userid);
+    public function init_template($device, $template) {
+        $userid = intval($device['userid']);
         
         if (empty($template)) {
             $result = $this->prepare_template($device);
@@ -123,15 +122,15 @@ class DeviceTemplate
         
         return array('success'=>true, 'message'=>'Device initialized');
     }
-    
-    protected function prepare_feeds($userid, $nodeid, &$feeds) {
+
+    protected function prepare_feeds($userid, $nodeid, $prefix, &$feeds) {
         global $feed_settings;
         
         require_once "Modules/feed/feed_model.php";
         $feed = new Feed($this->mysqli, $this->redis, $feed_settings);
         
         foreach($feeds as $f) {
-            $name = $f->name;
+            $f->name = $prefix.$f->name;
             if (!isset($f->tag)) {
                 $f->tag = $nodeid;
             }
@@ -148,11 +147,12 @@ class DeviceTemplate
         }
     }
 
-    protected function prepare_inputs($userid, $nodeid, &$inputs) {
+    protected function prepare_inputs($userid, $nodeid, $prefix, &$inputs) {
         require_once "Modules/input/input_model.php";
         $input = new Input($this->mysqli, $this->redis, null);
         
         foreach($inputs as $i) {
+            $i->name = $prefix.$i->name;
             if(!isset($i->node)) {
                 $i->node = $nodeid;
             }
@@ -168,9 +168,9 @@ class DeviceTemplate
             }
         }
     }
-    
+
     // Prepare the input process lists
-    protected function prepare_input_processes($userid, $feeds, &$inputs) {
+    protected function prepare_input_processes($userid, $prefix, $feeds, &$inputs) {
         global $user, $feed_settings;
         
         require_once "Modules/feed/feed_model.php";
@@ -188,7 +188,7 @@ class DeviceTemplate
             if (isset($i->id) && (isset($i->processList) || isset($i->processlist))) {
                 $processes = isset($i->processList) ? $i->processList : $i->processlist;
                 if (!empty($processes)) {
-                    $processes = $this->prepare_processes($feeds, $inputs, $processes, $process_list);
+                    $processes = $this->prepare_processes($prefix, $feeds, $inputs, $processes, $process_list);
                     if (isset($i->action) && $i->action != 'create') {
                         $processes_input = $input->get_processlist($i->id);
                         if (!isset($processes['success'])) {
@@ -212,9 +212,9 @@ class DeviceTemplate
             }
         }
     }
-    
+
     // Prepare the feed process lists
-    protected function prepare_feed_processes($userid, &$feeds, $inputs) {
+    protected function prepare_feed_processes($userid, $prefix, &$feeds, $inputs) {
         global $user, $feed_settings;
         
         require_once "Modules/feed/feed_model.php";
@@ -232,7 +232,7 @@ class DeviceTemplate
             if ($f->engine == Engine::VIRTUALFEED && isset($f->id) && (isset($f->processList) || isset($f->processlist))) {
                 $processes = isset($f->processList) ? $f->processList : $f->processlist;
                 if (!empty($processes)) {
-                    $processes = $this->prepare_processes($feeds, $inputs, $processes, $process_list);
+                    $processes = $this->prepare_processes($prefix, $feeds, $inputs, $processes, $process_list);
                     if (isset($f->action) && $f->action != 'create') {
                         $processes_input = $feed->get_processlist($f->id);
                         if (!isset($processes['success'])) {
@@ -256,9 +256,9 @@ class DeviceTemplate
             }
         }
     }
-    
+
     // Prepare template processes
-    protected function prepare_processes($feeds, $inputs, &$processes, $process_list) {
+    protected function prepare_processes($prefix, $feeds, $inputs, &$processes, $process_list) {
         $process_list_by_name = array();
         foreach ($process_list as $process_id => $process_item) {
             $name = $process_item[2];
@@ -288,6 +288,9 @@ class DeviceTemplate
                     if ($process_type != $process->arguments->type) {
                         $this->log->error("prepare_processes() Bad device template. Missmatch ProcessArg type. Got '$process->arguments->type' expected '$process_type'. process='$process_id'");
                         return array('success'=>false, 'message'=>"Bad device template. Missmatch ProcessArg type. Got '$process->arguments->type' expected '$process_type'. process='$process_id'");
+                    }
+                    else if ($process->arguments->type === ProcessArg::INPUTID || $process->arguments->type === ProcessArg::FEEDID) {
+                        $process->arguments->value = $prefix.$process->arguments->value;
                     }
                     
                     $result = $this->convert_process($feeds, $inputs, $process);
@@ -452,7 +455,6 @@ class DeviceTemplate
 
     // Converts template process
     protected function convert_process($feeds, $inputs, $process) {
-                
         if (isset($process->arguments->value)) {
             $value = $process->arguments->value;
         }
@@ -501,6 +503,19 @@ class DeviceTemplate
         
         $this->log->info("convertProcess() process process='$process->process' type='".$process->arguments->type."' value='" . $value . "'");
         return $process->process.":".$value;
+    }
+
+    protected function parse_prefix($nodeid, $name, $template) {
+        if (isset($template->prefix)) {
+            $prefix = $template->prefix;
+            if ($prefix === "node") {
+                return strtolower($nodeid)."_";
+            }
+            else if ($prefix === "name") {
+                return strtolower($name)."_";
+            }
+        }
+        return "";
     }
 
     protected function search_array($array, $key, $val) {

--- a/device_template.php
+++ b/device_template.php
@@ -90,7 +90,11 @@ class DeviceTemplate
         $userid = intval($userid);
         
         if (!is_object($template)) {
-            return array('success'=>false, 'message'=>'Invalid device template');
+            $result = $this->prepare_template($device);
+            if (isset($result["success"]) && !$result["success"]) {
+                return $result;
+            }
+            $template = $result;
         }
         
         if (isset($template->feeds)) {


### PR DESCRIPTION
Hei guys,

I finally found the time to start some PRs with long-overdue improvements/changes in my pipeline :)
This request would contain some minor fixes and features including

- Fixing long templates being unable to be initialized due to a max-length of GET parameters, hence _device/init.json?template={}_ is now a POST request
- If no _device/init.json?**template**_ parameter exists, the default template corresponding to the device type will be used without the prior option to deselect stuff... but this allows to just use the API request shown in _device/api_ to test stuff
- The delete button is no longer shown for the new device dialog
- _device/auth/..._ requests were moved to device_model.php with separate `if ($redis)` checks, as momentarily, instances without redis would automatically result in an incorrect response, where an unexisting device id was checked and a {"success":false, ...} would be returned.
- I added an optional "prefix" parameter to templates, with the possible values "name" or "node". This results in a prefix for input and feed names, where e.g. the configured input "status" in the template for the new device "foo" would be named "foo_status". This is most probably useless for most OEM purposes but in my case inputs had to be unique, hence this small feature.
- Syntax improvements n stuff 😄


I hope the MQTT authentication changes still work as intended, as I sadly was unable to thoroughly test them in a practical context^^
and as always, great work!