### PR TITLE
Redis caching

### DIFF
--- a/Views/device_api.php
+++ b/Views/device_api.php
@@ -51,8 +51,9 @@
 
 <p><b><?php echo _('Template actions'); ?></b></p>
 <table class="table">
+    <tr><td><?php echo _('List template metadata'); ?></td><td><a href="<?php echo $path; ?>device/template/listshort.json"><?php echo $path; ?>device/template/listshort.json</a></td></tr>
     <tr><td><?php echo _('List templates'); ?></td><td><a href="<?php echo $path; ?>device/template/list.json"><?php echo $path; ?>device/template/list.json</a></td></tr>
-    <tr><td><?php echo _('List templates short'); ?></td><td><a href="<?php echo $path; ?>device/template/listshort.json"><?php echo $path; ?>device/template/listshort.json</a></td></tr>
+    <tr><td><?php echo _('Reload templates'); ?></td><td><a href="<?php echo $path; ?>device/template/reload.json"><?php echo $path; ?>device/template/reload.json</a></td></tr>
     <tr><td><?php echo _('get template details'); ?></td><td><a href="<?php echo $path; ?>device/template/get.json?type=example"><?php echo $path; ?>device/template/get.json?type=example</a></td></tr>
     <tr><td><?php echo _('Prepare device initialization'); ?></td><td><a href="<?php echo $path; ?>device/template/prepare.json?id=1"><?php echo $path; ?>device/template/prepare.json?id=1</a></td></tr>
 </table>

--- a/Views/device_dialog.js
+++ b/Views/device_dialog.js
@@ -292,7 +292,12 @@ var device_dialog =
                 }
                 else {
                 	var type = device_dialog.deviceType;
-                    if (type != null && type != '') {
+                    var result = device.create(node, name, desc, type);
+                    if (typeof result.success !== 'undefined' && !result.success) {
+                        alert('Unable to create device:\n'+result.message);
+                        return false;
+                    }
+                    if (type != null) {
                         device_dialog.device = {
                                 id: result,
                                 nodeid: node,
@@ -300,15 +305,6 @@ var device_dialog =
                                 type: type
                         };
                         init = true;
-                    }
-                    else if (type != '') {
-                    	type = '';
-                    }
-                	
-                    var result = device.create(node, name, desc, type);
-                    if (typeof result.success !== 'undefined' && !result.success) {
-                        alert('Unable to create device:\n'+result.message);
-                        return false;
                     }
                     update();
                 }

--- a/Views/device_dialog.js
+++ b/Views/device_dialog.js
@@ -133,10 +133,10 @@ var device_dialog =
             $('#device-delete').show();
             $("#device-save").html("Save");
             if (this.device.type != null && this.device.type != '') {
-            	$("#device-init").show();
+                $("#device-init").show();
             }
             else {
-            	$("#device-init").hide();
+                $("#device-init").hide();
             }
         }
         else {
@@ -291,7 +291,7 @@ var device_dialog =
                     update();
                 }
                 else {
-                	var type = device_dialog.deviceType;
+                    var type = device_dialog.deviceType;
                     var result = device.create(node, name, desc, type);
                     if (typeof result.success !== 'undefined' && !result.success) {
                         alert('Unable to create device:\n'+result.message);

--- a/Views/device_dialog.js
+++ b/Views/device_dialog.js
@@ -131,8 +131,13 @@ var device_dialog =
             $('#device-config-devicekey').val(this.device.devicekey).prop("disabled", false);
             $("#device-config-devicekey-new").prop("disabled", false);
             $('#device-delete').show();
-            $("#device-init").show();
             $("#device-save").html("Save");
+            if (this.device.type != null && this.device.type != '') {
+            	$("#device-init").show();
+            }
+            else {
+            	$("#device-init").hide();
+            }
         }
         else {
             $('#device-config-node').val('');
@@ -286,18 +291,25 @@ var device_dialog =
                     update();
                 }
                 else {
-                    var result = device.create(node, name, desc, device_dialog.deviceType);
+                	var type = device_dialog.deviceType;
+                    if (type != null && type != '') {
+                        device_dialog.device = {
+                                id: result,
+                                nodeid: node,
+                                name: name,
+                                type: type
+                        };
+                        init = true;
+                    }
+                    else if (type != '') {
+                    	type = '';
+                    }
+                	
+                    var result = device.create(node, name, desc, type);
                     if (typeof result.success !== 'undefined' && !result.success) {
                         alert('Unable to create device:\n'+result.message);
                         return false;
                     }
-                    init = true;
-                    device_dialog.device = {
-                            id: result,
-                            nodeid: node,
-                            name: name,
-                            type: device_dialog.deviceType
-                    };
                     update();
                 }
                 $('#device-config-modal').modal('hide');

--- a/device_controller.php
+++ b/device_controller.php
@@ -17,7 +17,7 @@ function device_controller()
     if ($route->format == 'html')
     {
         if ($route->action == "view" && $session['write']) {
-            $templates = $device->get_template_list($session['userid']);
+            $templates = $device->get_template_list_meta($session['userid']);
             $result = view("Modules/device/Views/device_view.php", array('templates'=>$templates));
         }
         else if ($route->action == 'api') $result = view("Modules/device/Views/device_api.php", array());
@@ -63,11 +63,14 @@ function device_controller()
             if ($session['userid']>0 && $session['write']) $result = $device->autocreate($session['userid'],get('nodeid'),get('type'));
         }
         else if ($route->action == "template" && $route->subaction != "prepare" && $route->subaction != "init") {
-            if ($route->subaction == "list") {
-                if ($session['userid']>0 && $session['write']) $result = $device->get_template_list_full($session['userid']);
-            }
-            else if ($route->subaction == "listshort") {
+            if ($route->subaction == "listshort") {
                 if ($session['userid']>0 && $session['write']) $result = $device->get_template_list_meta($session['userid']);
+            }
+            else if ($route->subaction == "list") {
+                if ($session['userid']>0 && $session['write']) $result = $device->get_template_list($session['userid']);
+            }
+            else if ($route->subaction == "reload") {
+                if ($session['userid']>0 && $session['write']) $result = $device->reload_template_list($session['userid']);
             }
             else if ($route->subaction == "get") {
                 if ($session['userid']>0 && $session['write']) $result = $device->get_template($session['userid'], get('type'));

--- a/device_model.php
+++ b/device_model.php
@@ -199,8 +199,9 @@ class Device
             $device = (array) $this->redis->hGetAll("device:$id");
             // Verify, if the cached device contains the userid, to avoid compatibility issues
             // with former versions where the userid was not cached.
-            if (empty($device['userid'])) {
-                $device = $this->load_device_to_redis($id);
+            if (!isset($device['userid'])) {
+                $this->load_device_to_redis($id);
+                $device = $this->get($id);
             }
             $device['time'] = $this->redis->hget("device:lastvalue:".$id, 'time');
         }
@@ -234,8 +235,9 @@ class Device
             $device = $this->redis->hGetAll("device:$id");
             // Verify, if the cached device contains the userid, to avoid compatibility issues
             // with former versions where the userid was not cached.
-            if (empty($device['userid'])) {
-                $device = $this->load_device_to_redis($id);
+            if (!isset($device['userid'])) {
+                $this->load_device_to_redis($id);
+                $device = $this->get($id);
             }
             $device['time'] = $this->redis->hget("device:lastvalue:".$id, 'time');
             $devices[] = $device;

--- a/device_model.php
+++ b/device_model.php
@@ -240,6 +240,11 @@ class Device
             $device['time'] = $this->redis->hget("device:lastvalue:".$id, 'time');
             $devices[] = $device;
         }
+        usort($devices, function($d1, $d2) {
+            if($d1['nodeid'] == $d2['nodeid'])
+                return strcmp($d1['name'], $d2['name']);
+            return strcmp($d1['nodeid'], $d2['nodeid']);
+        });
         return $devices;
     }
 

--- a/device_model.php
+++ b/device_model.php
@@ -340,7 +340,7 @@ class Device
             $description = '';
         }
         
-        if (isset($type)) {
+        if (isset($type) && $type != 'null') {
             $type = preg_replace('/[^\/\|\,\w\s-:]/','', $type);
         } else {
             $type = '';

--- a/device_model.php
+++ b/device_model.php
@@ -356,7 +356,7 @@ class Device
                 // Add the device to redis
                 if ($this->redis) {
                     $this->redis->sAdd("user:device:$userid", $deviceid);
-                    $this->redis->hMSet("device:".$row->id, array(
+                    $this->redis->hMSet("device:".$deviceid, array(
                         'id'=>$deviceid,
                         'userid'=>$userid,
                         'nodeid'=>$nodeid,


### PR DESCRIPTION
Hi guys,

The comments by @pb66 reagarding the modules stability/seldom and strange bugs as discussed in [the Forum](https://community.openenergymonitor.org/t/development-devices-inputs-and-feeds-in-emoncms/4281/119) motivated me to take a look into it yesterday and I finally decided to overhaul the original redis caching by @chaveiro.

This PR includes one major and two small changes:

- The redis caching in the device module bothered me a while already, as it included a kinda unclean delete-everything-and-reload-everything-again-approach, which could probably result in a whole lot of unexpected synchronization errors. Hence I almost completely avoided using `load_list_to_redis()` and oriented myself on the approach of the feed and input modules. Specific devices will only be loaded to redis at creation and if non existant. Deletion will only ever happen in `delete()`. Cached tempalte meta data will never be deleted except for the specific API request `device/template/reload.json`, to enable manual reloading after changes in the database. This request could maybe be restricted to admin users and integrated into the admin panel at some point in the future.
- Returned device lists will always be sorted by Node and Name.
- The device dialog does not show or process device initialization for devices without a type (e.g. created by autocreate)