### PR TITLE
Improve dialog sidebar and template error handling

### DIFF
--- a/Views/device_api.php
+++ b/Views/device_api.php
@@ -1,6 +1,12 @@
 <?php global $path, $session, $user; ?>
 <style>
-  a.anchor{display: block; position: relative; top: -50px; visibility: hidden;}
+    a.anchor {
+        display: block;
+        position: relative;
+        top: -50px;
+        visibility: hidden;
+    }
+    .table td:nth-of-type(1) { width:25%; }
 </style>
 
 <h2><?php echo _('Device API'); ?></h2>

--- a/Views/device_dialog.css
+++ b/Views/device_dialog.css
@@ -1,0 +1,159 @@
+.modal-adjust {
+    width: 60%;
+    left: 20%; /* (100%-width)/2 */
+    margin-left: auto;
+    margin-right: auto;
+    overflow-y: hidden;
+}
+
+.modal-adjust .modal-body {
+    max-height: none;
+    overflow-y: hidden;
+}
+
+.modal-adjust .tooltip-inner {
+    max-width: 250px;
+}
+
+.modal-adjust .divider {
+    *width: 100%;
+    height: 1px;
+    margin: 9px 1px;
+    *margin: -5px 0 5px;
+    overflow: hidden;
+    background-color: #e5e5e5;
+    border-bottom: 1px solid #ffffff;
+}
+
+.modal-adjust .alert-comment {
+    margin: 0px;
+    color: #737373;
+    background-color: #f9f9f9;
+    border-color: #e6e6e6;
+}
+
+.modal-adjust .alert-comment h4 {
+    color: #737373;
+}
+
+.modal-adjust .content {
+    position: absolute;
+    left: 15px;
+    right: 0px;
+    bottom: 0px;
+    height: 100%;
+    overflow-y: auto;
+}
+
+.modal-overlay {
+    position: absolute;
+    top: 0; bottom:0; left: 0; right:0;
+    margin: auto;
+    background: rgba(255, 255, 255, .8) center;
+}
+.modal-content {
+    position: absolute;
+    left: 15px;
+    right: 0px;
+    padding-right: 15px;
+    margin-left: 15px;
+    margin-top: -15px;
+    height: 100%;
+    max-height: none;
+    overflow-y: auto;
+}
+
+.modal-content .btn-sidebar {
+  margin-bottom: 5px;
+}
+.modal-sidebar {
+    position: absolute;
+    margin-top: -15px;
+    margin-left: -15px;
+    max-height: none;
+    height: 100%;
+    width: 250px;
+    overflow-x: hidden;
+    overflow-y: auto;
+    background-color: #f2f2f2;
+    z-index: 1000;
+}
+.modal-sidebar .accordion {
+  margin-bottom: 0px;
+}
+.modal-sidebar .accordion-group {
+    margin-bottom: 0px;
+    border: 0px;
+    -webkit-border-radius: 0px;
+       -moz-border-radius: 0px;
+            border-radius: 0px;
+}
+.modal-sidebar .accordion-inner {
+    padding: 0px;
+    border-top: 0px;
+}
+.modal-sidebar .category-heading {
+    background-color: #cccccc;
+    border-bottom: 1px solid #d9d9d9;
+    cursor: pointer;
+}
+.modal-sidebar .category-heading:hover {
+    background-color: #d9d9d9;
+}
+.modal-sidebar .category-heading span {
+    font-weight: bold;
+    padding: 6px 6px 6px 10px;
+}
+.modal-sidebar .group-heading {
+    background-color: #e6e6e6;
+    border-bottom: 1px solid #ededed;
+    cursor: pointer;
+}
+.modal-sidebar .group-heading:hover {
+    background-color: #ededed;
+}
+.modal-sidebar .group-heading span {
+    font-weight: bold;
+    padding: 6px 6px 6px 16px;
+}
+.modal-sidebar .group-device {
+    padding: 8px 8px 8px 22px;
+    background-color: #f5f5f5;
+    border-bottom: 1px solid #fcfcfc;
+    cursor: pointer;
+}
+.modal-sidebar .group-device:hover {
+    background-color: #44b3e2;
+    color: #ffffff;
+}
+
+.device-selected {
+    background-color: #209ed3 !important;
+    color: #ffffff;
+}
+
+.device-input {
+    width: 100%;
+}
+.device-input th,
+.device-input td {
+    white-space: nowrap;
+    text-align: left;
+}
+.device-input th:nth-of-type(3) {
+    color: #888;
+    font-weight: normal;
+}
+.device-input td:nth-of-type(1) { width:108px; }
+.device-input td:nth-of-type(2) { width:168px; }
+
+.table-feeds td:nth-of-type(1) { width:14px; text-align: center; }
+.table-feeds td:nth-of-type(2) { width:5%; }
+.table-feeds td:nth-of-type(3) { width:15%; }
+.table-feeds td:nth-of-type(4) { width:25%; }
+
+.table-inputs td:nth-of-type(1) { width:14px; text-align: center; }
+.table-inputs td:nth-of-type(2) { width:5%; }
+.table-inputs td:nth-of-type(3) { width:5%; }
+.table-inputs td:nth-of-type(4) { width:10%; }
+.table-inputs td:nth-of-type(5) { width:25%; }

--- a/Views/device_dialog.js
+++ b/Views/device_dialog.js
@@ -428,41 +428,56 @@ var device_dialog =
 
     'drawInitProcessList': function (processList) {
         if (!processList || processList.length < 1) return "";
+
         var out = "";
         for (var i = 0; i < processList.length; i++) {
             var process = processList[i];
-            if (process['arguments'] != undefined && process['arguments']['value'] != undefined && process['arguments']['type'] != undefined) {
-                var name = "<small>"+process["name"]+"</small>";
-                var value = process['arguments']['value'];
-                
+            if (process['arguments'] != undefined && process['arguments']['type'] != undefined) {
                 var title;
-                var color = "info";
+                var label;
                 switch(process['arguments']['type']) {
                 case 0: // VALUE
-                    title = "Value: " + value;
+                	label = "important";
+                    title = "Value - ";
                     break;
                     
                 case 1: //INPUTID
-                    title = "Input: " + value;
+                	label = "warning";
+                    title = "Input - ";
                     break;
                     
                 case 2: //FEEDID
-                    title = "Feed: " + value;
+                	label = "info";
+                    title = "Feed - ";
+                    break;
+                    
+                case 3: // NONE
+                	label = "important";
+                    title = "";
                     break;
                     
                 case 4: // TEXT
-                    title = "Text: " + value;
+                	label = "important";
+                    title = "Text - ";
                     break;
-
+                    
                 case 5: // SCHEDULEID
-                    title = "Schedule: " + value;
+                	label = "warning";
+                    title = "Schedule - "
                     break;
-
+                    
                 default:
-                    title = value;
+                	label = "important";
+                    title = "ERROR - ";
                     break;
                 }
-                out += "<span class='label label-"+color+"' title='"+title+"' style='cursor:default'>"+name+"</span> ";
+            	title += process["name"];
+                
+                if (process['arguments']['value'] != undefined) {
+                	title += ": " + process['arguments']['value'];
+                }
+                
+                out += "<span class='label label-"+label+"' title='"+title+"' style='cursor:default'><small>"+process["short"]+"</small></span> ";
             }
         }
         return out;

--- a/Views/device_dialog.js
+++ b/Views/device_dialog.js
@@ -27,8 +27,6 @@ var device_dialog =
         this.adjustConfigModal();
         this.clearConfigModal();
 
-        var out = "";
-
         var categories = [];
         var devicesByCategory = {};
         for (var id in this.templates) {
@@ -50,7 +48,8 @@ var device_dialog =
         
         for (var i in categories) {
             var category = categories[i];
-
+            var categoryid = category.replace(/\W/g, '').toLowerCase();
+            
             var groups = [];
             var devicesByGroup = {};
             for (var i in devicesByCategory[category]) {
@@ -63,22 +62,39 @@ var device_dialog =
             }
             groups.sort();
             
-            out += "<tbody>"
-            out += "<tr class='category-header' category='"+category+"' style='background-color:#aaa; cursor:pointer'>";
-            out += "<td style='font-size:12px; padding:4px; padding-left:8px; font-weight:bold'>"+category+"</td>";
-            out += "</tr>";
-            out += "</tbody>";
+            $('#template-list').append(
+                "<div class='accordion-group'>" +
+                    "<div class='accordion-heading category-heading'>" +
+                        "<span class='accordion-toggle' data-toggle='collapse' " +
+                            "data-parent='#template-list' data-target='#template-"+categoryid+"-collapse'>" +
+                            category +
+                        "</span>" +
+                    "</div>" +
+                    "<div id='template-"+categoryid+"-collapse' class='accordion-body collapse'>" +
+                        "<div class='accordion-inner'>" +
+                            "<div id='template-"+categoryid+"' class='accordion'></div>" +
+                        "</div>" +
+                    "</div>" +
+                "</div>"
+            );
             
             for (var i in groups) {
                 var group = groups[i];
-                
-                out += "<tbody class='group-header' group='"+group+"' category='"+category+"' style='display:none'>"
-                out += "<tr style='background-color:#ccc; cursor:pointer'>";
-                out += "<td style='font-size:12px; padding:4px; padding-left:16px; font-weight:bold'>"+group+"</td>";
-                out += "</tr>";
-                out += "</tbody>";
-                
-                out += "<tbody class='group-body' group='"+group+"' category='"+category+"' style='display:none'>";
+                var groupid = group.replace(/\W/g, '').toLowerCase();
+                $('#template-'+categoryid).append(
+                    "<div class='accordion-group'>" +
+                        "<div class='accordion-heading group-heading'>" +
+                            "<span class='accordion-toggle' data-toggle='collapse' " +
+                                "data-parent='#template-"+categoryid+"' data-target='#template-"+categoryid+"-"+groupid+"-collapse'>" +
+                                group +
+                            "</span>" +
+                        "</div>" +
+                        "<div id='template-"+categoryid+"-"+groupid+"-collapse' class='accordion-body collapse'>" +
+                            "<div id='template-"+categoryid+"-"+groupid+"' class='accordion-inner'></div>" +
+                        "</div>" +
+                    "</div>"
+                );
+                var body = $('#template-'+categoryid+'-'+groupid);
                 
                 for (var i in devicesByGroup[group]) {
                     var id = devicesByGroup[group][i].id;
@@ -87,22 +103,26 @@ var device_dialog =
                         name = name.substr(0, 25) + "...";
                     }
                     
-                    out += "<tr class='group-row' type='"+id+"'>";
-                    out += "<td style='padding-left:24px; cursor:pointer'>"+name+"</td>";
-                    out += "</tr>";
+                    body.append(
+                        "<div id='template-"+categoryid+"-"+groupid+"-"+id.replace('/', '-')+"'" +
+                        		"data-type='"+id+"' class='group-device'>" +
+                            "<span>"+name+"</span>" +
+                        "</div>"
+                    );
                 }
-                out += "</tbody>";    
             }
         }
-        $("#template-table").html(out);
         
         if (this.deviceType != null && this.deviceType != '') {
             if (this.templates[this.deviceType]!=undefined) {
-                var template = this.templates[this.deviceType]
-                
-                $(".group-header[category='"+template.category+"']").show();
-                $(".group-body[category='"+template.category+"'][group='"+template.group+"']").show();
-                $(".group-row[type='"+this.deviceType+"']").addClass("device-selected");
+                var template = this.templates[this.deviceType];
+                var category = template.category.replace(/\W/g, '').toLowerCase();
+                var group = template.group.replace(/\W/g, '').toLowerCase();
+                var id = this.deviceType.replace('/', '-');
+
+                $("#template-"+category+"-collapse").collapse('show');
+                $("#template-"+category+"-"+group+"-collapse").collapse('show');
+                $("#template-"+category+"-"+group+"-"+id).addClass("device-selected");
                 
                 $('#template-description').html('<em style="color:#888">'+template.description+'</em>');
                 $('#template-info').show();
@@ -114,11 +134,10 @@ var device_dialog =
     },
 
     'clearConfigModal':function() {
-        $("#template-table").text('');
+        $("#template-list").text('');
         
-        var tooltip = "Defaults, like inputs and associated feeds will be automaticaly configured together with the device." +
-                "<br><br>" +
-                "Initializing a device usualy should only be done once on installation.<br>" +
+        var tooltip = "Defaults, like inputs and associated feeds will be automaticaly configured together with the device.<br>" +
+                "Initializing a device usualy should only be done once on installation. " +
                 "If the configuration was already applied, only missing inputs and feeds will be created.";
         
         $('#template-tooltip').attr("title", tooltip).tooltip({html: true});
@@ -160,73 +179,36 @@ var device_dialog =
             var h = height - $("#device-config-modal").position().top - 180;
             $("#device-config-body").height(h);
         }
-
-        $("#content-wrapper").css("transition","0");
-        $("#sidebar-wrapper").css("transition","0");
+        
         if (width < 1024) {
-            $("#content-wrapper").css("margin-left","0");
-            $("#sidebar-wrapper").css("width","0");
-            $("#sidebar-open").show();
-
-            $("#content-wrapper").css("transition","0.5s");
-            $("#sidebar-wrapper").css("transition","0.5s");
+            $("#device-sidebar-open").show();
+            $("#device-sidebar-close").show();
+            
+            $("#device-sidebar").css("transition","0.5s");
+            $("#device-sidebar").css("width","0");
+            
+            $("#device-content").css("transition","0.5s");
+            $("#device-content").css("margin-left","0");
+        	$("#device-config-modal").css("margin-left","0").css("margin-right","0");
         } else {
-            $("#content-wrapper").css("margin-left","250px");
-            $("#sidebar-wrapper").css("width","250px");
-            $("#sidebar-open").hide();
-            $("#sidebar-close").hide();
+            $("#device-sidebar-open").hide();
+            $("#device-sidebar-close").hide();
+            
+            $("#device-sidebar").css("transition","0");
+            $("#device-sidebar").css("width","250px");
+            
+            $("#device-content").css("transition","0");
+            $("#device-content").css("margin-left","250px");
+        	$("#device-config-modal").css("margin-left","auto").css("margin-right","auto");
         }
     },
 
     'registerConfigEvents':function() {
 
-        $('#template-table .category-header').off('click').on('click', function() {
-            var category = $(this).attr("category");
+        $("#template-list").off('click').on('click', '.group-device', function () {
+            var type = $(this).data("type");
             
-            var e = $(".group-header[category='"+category+"']");
-            if (e.is(":visible")) {
-                $(".group-body[category='"+category+"']").hide();
-                e.hide();
-            }
-            else {
-                e.show();
-
-                // If a device is selected and in the category to uncollapse, show and select it
-                if (device_dialog.deviceType != null && device_dialog.deviceType != '') {
-                    var template = device_dialog.templates[device_dialog.deviceType];
-                    if (template && category == template.category) {
-                        $(".group-body[category='"+template.category+"'][group='"+template.group+"']").show();
-                        $(".group-row[type='"+device_dialog.deviceType+"']").addClass("device-selected");
-                    }
-                }
-            }
-        });
-
-        $('#template-table .group-header').off('click').on('click', function() {
-            var group = $(this).attr("group");
-            var category = $(this).attr("category");
-            
-            var e = $(".group-body[group='"+group+"'][category='"+category+"']");
-            if (e.is(":visible")) {
-                e.hide();
-            }
-            else {
-                e.show();
-
-                // If a device is selected and in the category to uncollapse, show and select it
-                if (device_dialog.deviceType != null && device_dialog.deviceType != '') {
-                    var template = device_dialog.templates[device_dialog.deviceType];
-                    if (category == template.category && group == template.group) {
-                        $(".group-row[type='"+device_dialog.deviceType+"']").addClass("device-selected");
-                    }
-                }
-            }
-        });
-
-        $("#template-table .group-row").off('click').on('click', function () {
-            var type = $(this).attr("type");
-            
-            $(".group-row[type='"+device_dialog.deviceType+"']").removeClass("device-selected");
+            $(".group-device[data-type='"+device_dialog.deviceType+"']").removeClass("device-selected");
             if (device_dialog.deviceType !== type) {
                 $(this).addClass("device-selected");
                 device_dialog.deviceType = type;
@@ -243,18 +225,19 @@ var device_dialog =
                 $('#template-info').hide();
                 $("#device-init").show()
             }
+            if ($(window).width() < 1024) {
+                $("#device-sidebar").css("width","0");
+            }
             
             device_dialog.drawTemplate();
         });
 
-        $("#sidebar-open").off('click').on('click', function () {
-            $("#sidebar-wrapper").css("width","250px");
-            $("#sidebar-close").show();
+        $("#device-sidebar-open").off('click').on('click', function () {
+            $("#device-sidebar").css("width","250px");
         });
 
-        $("#sidebar-close").off('click').on('click', function () {
-            $("#sidebar-wrapper").css("width","0");
-            $("#sidebar-close").hide();
+        $("#device-sidebar-close").off('click').on('click', function () {
+            $("#device-sidebar").css("width","0");
         });
 
         $("#device-save").off('click').on('click', function () {
@@ -333,15 +316,15 @@ var device_dialog =
     },
 
     'drawTemplate':function() {
-        if (this.deviceType !== null && this.deviceType in this.templates) {
-            var template = this.templates[this.deviceType];
-            $('#template-description').html('<em style="color:#888">'+template.description+'</em>');
-            $('#template-info').show();
-        }
-        else {
+        if (device_dialog.deviceType == null || !device_dialog.deviceType in device_dialog.templates) {
             $('#template-description').text('');
             $('#template-info').hide();
+            return;
         }
+        
+        var template = device_dialog.templates[device_dialog.deviceType];
+        $('#template-description').html('<em style="color:#888">'+template.description+'</em>');
+        $('#template-info').show();
     },
 
     'loadInit': function() {
@@ -485,6 +468,17 @@ var device_dialog =
         return out;
     },
 
+    'adjustInitModal':function() {
+
+        var width = $(window).width();
+        var height = $(window).height();
+        
+        if ($("#device-init-modal").length) {
+            var h = height - $("#device-init-modal").position().top - 180;
+            $("#device-init-body").height(h);
+        }
+    },
+
     'parseTemplate': function() {
         var template = {};
         
@@ -509,17 +503,6 @@ var device_dialog =
         }
         
         return template;
-    },
-
-    'adjustInitModal':function() {
-
-        var width = $(window).width();
-        var height = $(window).height();
-        
-        if ($("#device-init-modal").length) {
-            var h = height - $("#device-init-modal").position().top - 180;
-            $("#device-init-body").height(h);
-        }
     },
 
     'loadDelete': function(device, tablerow) {

--- a/Views/device_dialog.php
+++ b/Views/device_dialog.php
@@ -2,88 +2,8 @@
     global $path;
 ?>
 
+<link href="<?php echo $path; ?>Modules/device/Views/device_dialog.css" rel="stylesheet">
 <script type="text/javascript" src="<?php echo $path; ?>Modules/device/Views/device_dialog.js"></script>
-
-<style>
-    .group-body tr:hover > td {
-        background-color: #44b3e2;
-    }
-
-    .device-selected {
-        background-color: #209ed3;
-        color: #fff;
-    }
-
-    .modal-adjust {
-        width: 60%; left:20%; /* (100%-width)/2 */
-        margin-left: auto; margin-right: auto;
-        overflow-y: hidden;
-    }
-
-    .modal-adjust .modal-body {
-        max-height: none;
-        overflow-y: hidden;
-    }
-
-    .modal-adjust .divider {
-        *width: 100%;
-        height: 1px;
-        margin: 9px 1px;
-        *margin: -5px 0 5px;
-        overflow: hidden;
-        background-color: #e5e5e5;
-        border-bottom: 1px solid #ffffff;
-    }
-
-    #template-info .tooltip-inner {
-        max-width: 500px;
-    }
-
-    #sidebar-wrapper {
-        position: absolute;
-        margin-top: -15px;
-        margin-left: -15px;
-        max-height: none;
-        height: 100%;
-        width: 250px;
-        overflow-y: auto;
-        background-color: #eee;
-        z-index: 1000;
-    }
-
-    #content-wrapper {
-        position: absolute;
-        left: 15px;
-        right: 15px;
-        margin-top: -15px;
-        margin-left: 250px;
-        height: 100%;
-        max-height: none;
-        overflow-y: auto;
-    }
-
-    #device-init-modal .content {
-        position: absolute;
-        left: 15px;
-        right: 0px;
-        bottom: 0px;
-        height: 100%;
-        overflow-y: auto;
-    }
-
-    #device-init-modal table td { text-align: left; }
-
-    #device-init-feeds table td:nth-of-type(1) { width:14px; text-align: center; }
-    #device-init-feeds table td:nth-of-type(2) { width:5%; }
-    #device-init-feeds table td:nth-of-type(3) { width:15%; }
-    #device-init-feeds table td:nth-of-type(4) { width:25%; }
-
-    #device-init-inputs table td:nth-of-type(1) { width:14px; text-align: center; }
-    #device-init-inputs table td:nth-of-type(2) { width:5%; }
-    #device-init-inputs table td:nth-of-type(3) { width:5%; }
-    #device-init-inputs table td:nth-of-type(4) { width:10%; }
-    #device-init-inputs table td:nth-of-type(5) { width:25%; }
-</style>
 
 <div id="device-config-modal" class="modal hide keyboard modal-adjust" tabindex="-1" role="dialog" aria-labelledby="device-config-modal-label" aria-hidden="true" data-backdrop="static">
     <div class="modal-header">
@@ -91,27 +11,25 @@
         <h3 id="device-config-modal-label"><?php echo _('Configure Device'); ?></h3>
     </div>
     <div id="device-config-body" class="modal-body">
-        <div id="sidebar-wrapper">
-            <div style="padding-left:10px;">
-                <div id="sidebar-close" style="float:right; cursor:pointer; padding:10px;"><i class="icon-remove"></i></div>
-                <h3><?php echo _('Devices'); ?></h3>
-            </div>
-            <div style="overflow-x: hidden; background-color:#f3f3f3; width:100%">
-                <table id="template-table" class="table"></table>
+        <div id="device-sidebar" class="modal-sidebar">
+            <h3 style="padding-left:10px;">
+                <span><?php echo _('Devices'); ?></span>
+                <span id="device-sidebar-close" style="float:right; cursor:pointer;"><i class="icon-remove" style="margin:8px;"></i></span>
+            </h3>
+            <div style="overflow-x: hidden; width:100%">
+                <div id="template-list" class="accordion"></div>
             </div>
         </div>
         
-        <div id="content-wrapper" style="max-width:1280px">
-            
-            <h3><?php echo _('Configuration'); ?></h3>
-            
-            <div id="navigation" style="padding-bottom:5px;">
-                <button class="btn" id="sidebar-open"><i class="icon-list"></i></button>
-            </div>
+        <div id="device-content" class="modal-content">
+            <h3>
+                <span id="device-sidebar-open" class="btn btn-sidebar"><i class="icon-th-list"></i></span>
+                <span><?php echo _('Configuration'); ?></span>
+            </h3>
             
             <span id="template-info" style="display:none;">
                 <span id="template-description"></span>
-                <span id="template-tooltip" data-toggle="tooltip" data-placement="bottom">
+                <span id="template-tooltip" data-toggle="tooltip" data-placement="bottom" data-container="#device-config-modal">
                     <i class="icon-info-sign" style="cursor:pointer; padding-left:6px;"></i>
                 </span>
             </span>
@@ -119,10 +37,10 @@
             <div class="divider"></div>
             
             <label><b><?php echo _('Node'); ?></b></label>
-            <input id="device-config-node" class="input-medium" type="text">
+            <input id="device-config-node" class="input-medium" type="text" required>
             
             <label><b><?php echo _('Name'); ?></b></label>
-            <input id="device-config-name" class="input-large" type="text">
+            <input id="device-config-name" class="input-large" type="text" required>
             
             <label><b><?php echo _('Location'); ?></b></label>
             <input id="device-config-description" class="input-large" type="text">
@@ -155,7 +73,7 @@
         
             <div id="device-init-feeds" style="display:none; margin-top:10px;">
                 <label><b><?php echo _('Feeds'); ?></b></label>
-                <table class="table table-hover">
+                <table class="table table-hover table-feeds">
                     <tr>
                         <th></th>
                         <th></th>
@@ -169,7 +87,7 @@
             
             <div id="device-init-inputs" style="display:none">
                 <label><b><?php echo _('Inputs'); ?></b></label>
-                <table class="table table-hover">
+                <table class="table table-hover table-inputs">
                     <tr>
                         <th></th>
                         <th></th>

--- a/Views/device_view.php
+++ b/Views/device_view.php
@@ -25,9 +25,9 @@
 
 <div>
     <div id="api-help-header" style="float:right;"><a href="api"><?php echo _('Devices Help'); ?></a></div>
-    <div id="local-header"><h2><?php echo _('Devices'); ?></h2></div>
+    <div id="device-header"><h2><?php echo _('Devices'); ?></h2></div>
 
-    <div id="table"><div align='center'>loading...</div></div>
+    <div id="table"></div>
 
     <div id="device-none" class="hide">
         <div class="alert alert-block">
@@ -45,6 +45,8 @@
     <div id="toolbar_bottom"><hr>
         <button id="device-new" class="btn btn-small" >&nbsp;<i class="icon-plus-sign" ></i>&nbsp;<?php echo _('New device'); ?></button>
     </div>
+	
+	<div id="device-loader" class="ajax-loader"></div>
 </div>
 
 <?php require "Modules/device/Views/device_dialog.php"; ?>
@@ -104,11 +106,14 @@
       table.draw();
       if (table.data.length != 0) {
         $("#device-none").hide();
-        $("#local-header").show();
+        $("#device-header").show();
+        $("#api-help-header").show();
       } else {
         $("#device-none").show();
-        $("#local-header").hide();
+        $("#device-header").hide();
+        $("#api-help-header").hide();
       }
+      $("#device-loader").hide();
     }});
   }
 
@@ -134,7 +139,6 @@
   });
 
   $("#table").bind("onDelete", function(e,id,row) {
-
     // Get device of clicked row
     var localDevice = device.get(id);
     device_dialog.loadDelete(localDevice, row);

--- a/device_controller.php
+++ b/device_controller.php
@@ -36,8 +36,8 @@ function device_controller()
             if ($route->subaction=="request") {
                 // 1. Register request for authentication details, or provide if allowed
                 $result = $device->request_auth($_SERVER['REMOTE_ADDR']);
-                if (isset($result["success"])) {
-                    $result = $result["message"];
+                if (isset($result['success'])) {
+                    $result = $result['message'];
                 }
                 $route->format = "text";
             }

--- a/device_model.php
+++ b/device_model.php
@@ -226,10 +226,9 @@ class Device
         $userid = intval($userid);
         
         if (!$this->redis->exists("user:device:$userid")) {
-            $this->log->info("Load devices to redis in get_list_redis");
             $this->load_list_to_redis($userid);
         }
-
+        
         $devices = array();
         $deviceids = $this->redis->sMembers("user:device:$userid");
         foreach ($deviceids as $id) {
@@ -497,6 +496,10 @@ class Device
         }
     }
 
+    public function get_template_list($userid) {
+        return $this->load_template_list($userid);
+    }
+
     public function get_template_list_meta($userid) {
         $templates = array();
         
@@ -541,15 +544,11 @@ class Device
         return array('success'=>false, 'message'=>'Device template does not exist');
     }
 
-    public function get_template_list($userid) {
-        return $this->load_template_list($userid);
-    }
-
     public function get_template($userid, $id) {
         $userid = intval($userid);
         
         $result = $this->get_template_meta($userid, $id);
-        if (isset($result['success']) && !$result['success']) {
+        if (!empty($result["success"])) {
             return $result;
         }
         $module = $result['module'];
@@ -557,7 +556,7 @@ class Device
         if ($class != null) {
             return $class->get_template($userid, $id);
         }
-        return array('success'=>false, 'message'=>'Unknown error while loading device template details');
+        return array('success'=>false, 'message'=>'Device template class is not defined');
     }
 
     public function prepare_template($id) {
@@ -566,7 +565,7 @@ class Device
         $device = $this->get($id);
         if (isset($device['type']) && $device['type'] != 'null' && $device['type']) {
             $result = $this->get_template_meta($device['userid'], $device['type']);
-            if (isset($result['success']) && !$result['success']) {
+            if (!empty($result["success"])) {
                 return $result;
             }
             $module = $result['module'];
@@ -584,7 +583,7 @@ class Device
         
         $device = $this->get($id);
         $result = $this->init_template($device, $template);
-        if (isset($result) && !$result['success']) {
+        if (!empty($result["success"])) {
             return $result;
         }
         return array('success'=>true, 'message'=>'Device initialized');
@@ -595,7 +594,7 @@ class Device
         
         if (isset($device['type']) && $device['type'] != 'null' && $device['type']) {
             $result = $this->get_template_meta($device['userid'], $device['type']);
-            if (isset($result['success']) && !$result['success']) {
+            if (!empty($result["success"])) {
                 return $result;
             }
             $module = $result['module'];
@@ -611,11 +610,11 @@ class Device
     public function reload_template_list($userid) {
         $userid = intval($userid);
         
-        $templates = $this->load_template_list($userid);
-        if (isset($templates) && count($templates) > 0) {
-            return array('success'=>true, 'message'=>'Templates successfully reloaded');
+        $result = $this->load_template_list($userid);
+        if (!empty($result["success"])) {
+            return $result;
         }
-        return array('success'=>false, 'message'=>'Unknown error while reloading templates');
+        return array('success'=>true, 'message'=>'Templates successfully reloaded');
     }
 
     private function load_template_list($userid) {
@@ -637,8 +636,11 @@ class Device
             if (filetype("Modules/".$dir[$i])=='dir' || filetype("Modules/".$dir[$i])=='link') {
                 $class = $this->get_module_class($dir[$i], self::TEMPLATE);
                 if ($class != null) {
-                    $module_templates = $class->get_template_list($userid);
-                    foreach($module_templates as $key => $value) {
+                    $result = $class->get_template_list($userid);
+                    if (!empty($result["success"])) {
+                        return $result;
+                    }
+                    foreach($result as $key => $value) {
                         $this->cache_template($dir[$i], $key, $value);
                         $templates[$key] = $value;
                     }

--- a/device_model.php
+++ b/device_model.php
@@ -319,7 +319,7 @@ class Device
         }
         
         $result = $this->set_fields($deviceid,json_encode(array("name"=>$name,"nodeid"=>$nodeid,"type"=>$type)));
-        if ($result["success"]==true) {
+        if ($result['success']==true) {
             return $this->init_template($deviceid);
         } else {
             return $result;
@@ -548,7 +548,7 @@ class Device
         $userid = intval($userid);
         
         $result = $this->get_template_meta($userid, $id);
-        if (isset($result["success"]) && $result["success"] == false) {
+        if (isset($result['success']) && $result['success'] == false) {
             return $result;
         }
         $module = $result['module'];
@@ -583,7 +583,7 @@ class Device
         
         $device = $this->get($id);
         $result = $this->init_template($device, $template);
-        if (isset($result["success"]) && $result["success"] == false) {
+        if (isset($result['success']) && $result['success'] == false) {
             return $result;
         }
         return array('success'=>true, 'message'=>'Device initialized');
@@ -594,7 +594,7 @@ class Device
         
         if (isset($device['type']) && $device['type'] != 'null' && $device['type']) {
             $result = $this->get_template_meta($device['userid'], $device['type']);
-            if (isset($result["success"]) && $result["success"] == false) {
+            if (isset($result['success']) && $result['success'] == false) {
                 return $result;
             }
             $module = $result['module'];
@@ -611,7 +611,7 @@ class Device
         $userid = intval($userid);
         
         $result = $this->load_template_list($userid);
-        if (isset($result["success"]) && $result["success"] == false) {
+        if (isset($result['success']) && $result['success'] == false) {
             return $result;
         }
         return array('success'=>true, 'message'=>'Templates successfully reloaded');
@@ -637,7 +637,7 @@ class Device
                 $class = $this->get_module_class($dir[$i], self::TEMPLATE);
                 if ($class != null) {
                     $result = $class->get_template_list($userid);
-                    if (isset($result["success"]) && $result["success"] == false) {
+                    if (isset($result['success']) && $result['success'] == false) {
                         return $result;
                     }
                     foreach($result as $key => $value) {

--- a/device_model.php
+++ b/device_model.php
@@ -548,7 +548,7 @@ class Device
         $userid = intval($userid);
         
         $result = $this->get_template_meta($userid, $id);
-        if (!empty($result["success"])) {
+        if (isset($result["success"]) && $result["success"] == false) {
             return $result;
         }
         $module = $result['module'];
@@ -565,7 +565,7 @@ class Device
         $device = $this->get($id);
         if (isset($device['type']) && $device['type'] != 'null' && $device['type']) {
             $result = $this->get_template_meta($device['userid'], $device['type']);
-            if (!empty($result["success"])) {
+            if (isset($result["success"]) && $result["success"] == false) {
                 return $result;
             }
             $module = $result['module'];
@@ -583,7 +583,7 @@ class Device
         
         $device = $this->get($id);
         $result = $this->init_template($device, $template);
-        if (!empty($result["success"])) {
+        if (isset($result["success"]) && $result["success"] == false) {
             return $result;
         }
         return array('success'=>true, 'message'=>'Device initialized');
@@ -594,7 +594,7 @@ class Device
         
         if (isset($device['type']) && $device['type'] != 'null' && $device['type']) {
             $result = $this->get_template_meta($device['userid'], $device['type']);
-            if (!empty($result["success"])) {
+            if (isset($result["success"]) && $result["success"] == false) {
                 return $result;
             }
             $module = $result['module'];
@@ -611,7 +611,7 @@ class Device
         $userid = intval($userid);
         
         $result = $this->load_template_list($userid);
-        if (!empty($result["success"])) {
+        if (isset($result["success"]) && $result["success"] == false) {
             return $result;
         }
         return array('success'=>true, 'message'=>'Templates successfully reloaded');
@@ -637,7 +637,7 @@ class Device
                 $class = $this->get_module_class($dir[$i], self::TEMPLATE);
                 if ($class != null) {
                     $result = $class->get_template_list($userid);
-                    if (!empty($result["success"])) {
+                    if (isset($result["success"]) && $result["success"] == false) {
                         return $result;
                     }
                     foreach($result as $key => $value) {

--- a/device_template.php
+++ b/device_template.php
@@ -47,7 +47,7 @@ class DeviceTemplate
     public function get_template($userid, $type) {
         $type = preg_replace('/[^\p{L}_\p{N}\s-:]/u','', $type);
         $result = $this->load_template_list($userid);
-        if (!empty($result["success"])) {
+        if (isset($result["success"]) && $result["success"] == false) {
             return $result;
         }
         if (!isset($result[$type])) {
@@ -96,7 +96,7 @@ class DeviceTemplate
         
         if (empty($template)) {
             $result = $this->prepare_template($device);
-            if (!empty($result["success"])) {
+            if (isset($result["success"]) && $result["success"] == false) {
                 return $result;
             }
             $template = $result;

--- a/device_template.php
+++ b/device_template.php
@@ -35,6 +35,9 @@ class DeviceTemplate
         foreach(new RecursiveIteratorIterator($iti) as $file){
             if(strpos($file ,".json") !== false){
                 $content = json_decode(file_get_contents($file));
+                if (json_last_error() != 0) {
+                    return array('success'=>false, 'message'=>"Error reading file $file: ".json_last_error_msg());
+                }
                 $list[basename($file, ".json")] = $content;
             }
         }
@@ -43,11 +46,14 @@ class DeviceTemplate
 
     public function get_template($userid, $type) {
         $type = preg_replace('/[^\p{L}_\p{N}\s-:]/u','', $type);
-        $list = $this->load_template_list($userid);
-        if (!isset($list[$type])) {
+        $result = $this->load_template_list($userid);
+        if (!empty($result["success"])) {
+            return $result;
+        }
+        if (!isset($result[$type])) {
             return array('success'=>false, 'message'=>'Device template "'.$type.'" not found');
         }
-        return $list[$type];
+        return $result[$type];
     }
 
     public function prepare_template($device) {
@@ -90,7 +96,7 @@ class DeviceTemplate
         
         if (empty($template)) {
             $result = $this->prepare_template($device);
-            if (isset($result["success"]) && !$result["success"]) {
+            if (!empty($result["success"])) {
                 return $result;
             }
             $template = $result;


### PR DESCRIPTION
Hi guys,

as a result of the issues #21 and #22 I quickly patched my latest changes in a PR and addressed both issues in it.
In general, I changed the sidebar categories and groups as bootstrap collapsable accordions, making the whole UI smoother and a little bit more pretty 😉

But most importantly, I improved the whole error handling especially for caching and template meta data generation. Faulty json code will now be indicated with an `array('success'=>false, 'message'=>"Error reading file $file: ".json_last_error_msg());`