### PR TITLE
JSON in solar file not valid

### DIFF
--- a/data/CircuitSetup/circuitsetup-split-phase_solar.json
+++ b/data/CircuitSetup/circuitsetup-split-phase_solar.json
@@ -151,7 +151,7 @@
 					"arguments": {"type": "ProcessArg::FEEDID", "value": "import_kwh" }
 				}
 			]
-		}
+		},
 		{
 			"name": "SolarW",
 			"description": "Solar Power",
@@ -163,7 +163,7 @@
 				{
 					"process": "power_to_kwh",
 					"arguments": {"type": "ProcessArg::FEEDID", "value": "solar_kwh" }
-				}
+				},
 				{
 					"process": "add_input",
 					"arguments": {"type": "ProcessArg::INPUTID", "value": "W" }


### PR DESCRIPTION
The solar file was missing a couple of commas. This meant that the entire device menu would appear blank.