### PR TITLE
Made the solar name shorter so it is visible in the menu

### DIFF
--- a/data/CircuitSetup/circuitsetup-split-phase_solar.json
+++ b/data/CircuitSetup/circuitsetup-split-phase_solar.json
@@ -1,5 +1,5 @@
 {
-	"name": "Split Single Phase Meter + Solar",
+	"name": "Solar Kit",
 	"category": "CircuitSetup",
 	"group": "Energy Meters",
 	"description": "CircuitSetup Split Single Phase Energy Meter with Solar",


### PR DESCRIPTION
The name for the CircuitSetup solar kit was too long and not easily distinguishable from the single phase meter.