### PR TITLE
Fix incorrect naming of single phase OpenEVSE.

### DIFF
--- a/data/OpenEVSE/openevse.json
+++ b/data/OpenEVSE/openevse.json
@@ -1,5 +1,5 @@
 {
-    "name": "Three-phase",
+    "name": "Single-phase",
     "category": "EVSE",
     "group": "OpenEVSE",
     "description": "OpenEVSE / EmonEVSE auto configuration",


### PR DESCRIPTION
This has caused me much confusion whilst attempting to set this up. Looks like a simple mistake when initially setting up.